### PR TITLE
Bump stylish-haskell to v0.9.2.2

### DIFF
--- a/stylish-haskell/Dockerfile
+++ b/stylish-haskell/Dockerfile
@@ -4,7 +4,7 @@ ENV LANG en_US.UTF-8
 ENV PATH /root/.local/bin:$PATH
 RUN stack upgrade
 RUN stack setup
-RUN stack install stylish-haskell
+RUN stack install stylish-haskell-0.9.2.2
 
 FROM fpco/stack-run:lts
 MAINTAINER Pat Brisbin <pbrisbin@gmail.com>

--- a/stylish-haskell/info.yaml
+++ b/stylish-haskell/info.yaml
@@ -1,6 +1,6 @@
 ---
 name: stylish-haskell
-image: restyled/restyler-stylish-haskell:v0.9.2.0
+image: restyled/restyler-stylish-haskell:v0.9.2.2
 command:
 - stylish-haskell
 - "--inplace"


### PR DESCRIPTION
This fixes stylish-haskell for `BlockArguments` extension.

I guess you will upload the new image yourself?
I don't see a CI config for that and I assume I don't have rights to do that myself :)