### PR TITLE
A bunch of miscellaneous improvements and new fixers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+git:
+  depth: false  # fetch all branches
+language: python
+services: [docker]
+matrix:
+  include:
+    - env: TARGET=astyle/Dockerfile.tested
+    - env: TARGET=autopep8/Dockerfile.tested
+    - env: TARGET=brittany/Dockerfile.tested
+    - env: TARGET=dfmt/Dockerfile.tested
+    - env: TARGET=elm-format/Dockerfile.tested
+    - env: TARGET=google-java-format/Dockerfile.tested
+    - env: TARGET=hindent/Dockerfile.tested
+    - env: TARGET=hlint/Dockerfile.tested
+    - env: TARGET=pg_format/Dockerfile.tested
+    - env: TARGET=php-cs-fixer/Dockerfile.tested
+    - env: TARGET=prettier/Dockerfile.tested
+    - env: TARGET=rubocop/Dockerfile.tested
+    - env: TARGET=rustfmt/Dockerfile.tested
+    - env: TARGET=shfmt/Dockerfile.tested
+    - env: TARGET=stylish-haskell/Dockerfile.tested
+    - env: TARGET=terraform/Dockerfile.tested
+    - env: TARGET=generate-travis
+install: pip install cram
+script: build/make-if-target-changed "$TARGET"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     - env: TARGET=pg_format/Dockerfile.tested
     - env: TARGET=php-cs-fixer/Dockerfile.tested
     - env: TARGET=prettier/Dockerfile.tested
+    - env: TARGET=reorder-python-imports/Dockerfile.tested
     - env: TARGET=rubocop/Dockerfile.tested
     - env: TARGET=rustfmt/Dockerfile.tested
     - env: TARGET=shfmt/Dockerfile.tested

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - env: TARGET=shfmt/Dockerfile.tested
     - env: TARGET=stylish-haskell/Dockerfile.tested
     - env: TARGET=terraform/Dockerfile.tested
+    - env: TARGET=yapf/Dockerfile.tested
     - env: TARGET=generate-travis
 install: pip install cram
 script: build/make-if-target-changed "$TARGET"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   include:
     - env: TARGET=astyle/Dockerfile.tested
     - env: TARGET=autopep8/Dockerfile.tested
+    - env: TARGET=black/Dockerfile.tested
     - env: TARGET=brittany/Dockerfile.tested
     - env: TARGET=dfmt/Dockerfile.tested
     - env: TARGET=elm-format/Dockerfile.tested

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ restylers.yaml: */info.yaml
 	echo > $@
 
 %/Dockerfile.tested: %/Dockerfile.built test/%.t
-	cram "test/$*.t"
+	cram --shell=bash "test/$*.t"
 	echo > $@
 
 %/Dockerfile.built: %/Dockerfile %/info.yaml

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,5 @@ release: all
 	git commit -m 'Update restylers.yaml'
 	git tag -s -m "$(RELASE_TAG)" "$(RELASE_TAG)"
 	git push --follow-tags
+
+.SECONDARY:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ restylers.yaml: */info.yaml
 	./build/restyler-meta get "$*" image | ./build/push-image
 	echo > $@
 
-%/Dockerfile.tested: %/Dockerfile.built
+%/Dockerfile.tested: %/Dockerfile.built test/%.t
 	cram "test/$*.t"
 	echo > $@
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ restylers.yaml: */info.yaml
 	docker build --tag "$$(./build/restyler-meta get "$*" image)" "$*"
 	echo > $@
 
+.PHONY: generate-travis
+generate-travis:
+	build/generate-travis
+
 RELASE_TAG ?= $(shell date +'%Y%m%d')
 
 .PHONY: release

--- a/autopep8/Dockerfile
+++ b/autopep8/Dockerfile
@@ -1,8 +1,7 @@
-FROM python:3.6
+FROM python:3.7-alpine
 MAINTAINER Pat Brisbin <pbrisbin@gmail.com>
-ENV LANG en_US.UTF-8
-RUN pip install autopep8
-RUN mkdir -p /code
+ENV LANG C.UTF-8
+RUN pip install autopep8==1.4.4
 WORKDIR /code
 ENTRYPOINT []
 CMD ["autopep8", "--help"]

--- a/black/Dockerfile
+++ b/black/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7-alpine
+LABEL maintainer=asottile@umich.edu
+ENV LANG C.UTF-8
+RUN pip install black==19.3b0
+WORKDIR /code
+ENTRYPOINT []
+CMD ["black", "--help"]

--- a/black/info.yaml
+++ b/black/info.yaml
@@ -1,9 +1,8 @@
 ---
-name: autopep8
-image: restyled/restyler-autopep8:v1.4.4
+name: black
+image: restyled/restyler-black:v19.3b0
 command:
-- autopep8
-- "--in-place"
+- black
 arguments: []
 include:
 - "**/*.py"
@@ -12,7 +11,7 @@ interpreters:
 supports_arg_sep: true
 supports_multiple_paths: true
 documentation:
-- https://github.com/hhatto/autopep8
+- https://github.com/python/black
 metadata:
   languages:
   - Python

--- a/build/generate-travis
+++ b/build/generate-travis
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import os.path
+import sys
+
+
+def main() -> int:
+    tests = [f for f in os.listdir('test') if f.endswith('.t')]
+    names = sorted(os.path.splitext(f)[0] for f in tests)
+    targets = '\n'.join(
+        f'    - env: TARGET={name}/Dockerfile.tested'
+        for name in names
+    )
+    contents = f'''\
+git:
+  depth: false  # fetch all branches
+language: python
+services: [docker]
+matrix:
+  include:
+{targets}
+    - env: TARGET=generate-travis
+install: pip install cram
+script: build/make-if-target-changed "$TARGET"
+'''
+    with open('.travis.yml') as f:
+        orig_contents = f.read()
+    if orig_contents != contents:
+        print('.travis.yml updated!', file=sys.stderr)
+        with open('.travis.yml', 'w') as f:
+            f.write(contents)
+        return 1
+    else:
+        print('.travis.yml already up to date!', file=sys.stderr)
+        return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/build/make-if-target-changed
+++ b/build/make-if-target-changed
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import os.path
+import subprocess
+import sys
+
+
+def is_changed(target: str) -> bool:
+    # always want to run `generate-travis`
+    if target == 'generate-travis':
+        return True
+
+    target_name = os.path.dirname(target)
+
+    cmd = ('git', 'diff', '--name-only', 'origin/master...HEAD')
+    changed_files = subprocess.check_output(cmd).decode().splitlines()
+    for filename in changed_files:
+        if filename.startswith(f'{target_name}/'):
+            return True
+        elif filename == f'test/{target_name}.t':
+            return True
+    else:
+        return False
+
+
+def main() -> int:
+    target = sys.argv[1]
+    if is_changed(target):
+        print(f'changes detected for {target}, building...', flush=True)
+        os.execvp('make', ('make', target))
+    else:
+        print(f'no changes detected for target {target}!', flush=True)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/reorder-python-imports/Dockerfile
+++ b/reorder-python-imports/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7-alpine
+LABEL maintainer=asottile@umich.edu
+ENV LANG C.UTF-8
+RUN pip install reorder-python-imports==1.6.0
+WORKDIR /code
+ENTRYPOINT []
+CMD ["reorder-python-imports", "--help"]

--- a/reorder-python-imports/info.yaml
+++ b/reorder-python-imports/info.yaml
@@ -1,0 +1,18 @@
+---
+name: reorder-python-imports
+image: restyled/restyler-reorder-python-imports:v1.6.0
+command:
+- reorder-python-imports
+- "--exit-zero-even-if-changed"
+arguments: []
+include:
+- "**/*.py"
+interpreters:
+- python
+supports_arg_sep: true
+supports_multiple_paths: true
+documentation:
+- https://github.com/asottile/reorder_python_imports
+metadata:
+  languages:
+  - Python

--- a/test/black.t
+++ b/test/black.t
@@ -1,0 +1,42 @@
+  $ source "$TESTDIR/helper.sh"
+  If you don't see this, setup failed
+
+black
+
+  $ run_restyler black crazy.py
+  reformatted crazy.py
+  All done! \xe2\x9c\xa8 \xf0\x9f\x8d\xb0 \xe2\x9c\xa8 (esc)
+  1 file reformatted.
+  diff --git i/crazy.py w/crazy.py
+  index 9941de7..ab602ed 100644
+  --- i/crazy.py
+  +++ w/crazy.py
+  @@ -1,9 +1,22 @@
+  -import math, sys;
+  +import math, sys
+  +
+  +
+   def example1():
+       ####This is a long comment. This should be wrapped to fit within 72 characters.
+  -    some_tuple=(   1,2, 3,'a'  );
+  -    some_variable={'long':'Long code lines should be wrapped within 79 characters.',
+  -    'other':[math.pi, 100,200,300,9876543210,'This is a long string that goes on'],
+  -    'more':{'inner':'This whole logical line should be wrapped.',some_tuple:[1,
+  -    20,300,40000,500000000,60000000000000000]}}
+  +    some_tuple = (1, 2, 3, "a")
+  +    some_variable = {
+  +        "long": "Long code lines should be wrapped within 79 characters.",
+  +        "other": [
+  +            math.pi,
+  +            100,
+  +            200,
+  +            300,
+  +            9876543210,
+  +            "This is a long string that goes on",
+  +        ],
+  +        "more": {
+  +            "inner": "This whole logical line should be wrapped.",
+  +            some_tuple: [1, 20, 300, 40000, 500000000, 60000000000000000],
+  +        },
+  +    }
+       return (some_tuple, some_variable)

--- a/test/fixtures/import_sort.py
+++ b/test/fixtures/import_sort.py
@@ -1,0 +1,7 @@
+import os, sys
+from argparse import ArgumentParser
+
+from foo import bar
+from baz import womp
+
+from crazy import example1

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -4,7 +4,7 @@ run_restyler() {
 
   "$TESTDIR"/../build/restyler-meta run "$name" "$@" || exit 1
 
-  git diff "$@"
+  git diff --src-prefix=i/ --dst-prefix=w/ "$@"
 }
 
 set -e

--- a/test/reorder-python-imports.t
+++ b/test/reorder-python-imports.t
@@ -1,0 +1,22 @@
+  $ source "$TESTDIR/helper.sh"
+  If you don't see this, setup failed
+
+reorder-python-imports
+
+  $ run_restyler reorder-python-imports import_sort.py
+  Reordering imports in import_sort.py
+  diff --git i/import_sort.py w/import_sort.py
+  index 48bfd1c..669f241 100644
+  --- i/import_sort.py
+  +++ w/import_sort.py
+  @@ -1,7 +1,8 @@
+  -import os, sys
+  +import os
+  +import sys
+   from argparse import ArgumentParser
+   
+  -from foo import bar
+   from baz import womp
+  +from foo import bar
+   
+   from crazy import example1

--- a/test/rubocop.t
+++ b/test/rubocop.t
@@ -9,16 +9,21 @@ rubocop
   
   Offenses:
   
+  four.rb:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
+  # bad - four spaces
+  ^
   four.rb:3:1: C: [Corrected] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
       do_something
   ^^^^
   
-  1 file inspected, 1 offense detected, 1 offense corrected
+  1 file inspected, 2 offenses detected, 2 offenses corrected
   diff --git i/four.rb w/four.rb
-  index bcea85b..04d7c60 100644
+  index bcea85b..18db5ae 100644
   --- i/four.rb
   +++ w/four.rb
-  @@ -1,4 +1,4 @@
+  @@ -1,4 +1,6 @@
+  +# frozen_string_literal: true
+  +
    # bad - four spaces
    def some_method
   -    do_something
@@ -33,7 +38,10 @@ rubocop with incorrectable offenses (anyw8 example)
   
   Offenses:
   
-  andyw8_user.rb:1:1: C: Style/Documentation: Missing top-level class documentation comment.
+  andyw8_user.rb:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
+  class User < ApplicationRecord
+  ^
+  andyw8_user.rb:3:1: C: Style/Documentation: Missing top-level class documentation comment.
   class User < ApplicationRecord
   ^^^^^
   andyw8_user.rb:10:34: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
@@ -45,22 +53,28 @@ rubocop with incorrectable offenses (anyw8 example)
   andyw8_user.rb:11:68: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
     has_many :created_topics, foreign_key: "creator_id", class_name: "Topic", dependent: :nullify
                                                                      ^^^^^^^
-  andyw8_user.rb:11:81: C: Metrics/LineLength: Line is too long. [95/80]
+  andyw8_user.rb:13:81: C: Metrics/LineLength: Line is too long. [95/80]
     has_many :created_topics, foreign_key: 'creator_id', class_name: 'Topic', dependent: :nullify
                                                                                   ^^^^^^^^^^^^^^^
   andyw8_user.rb:27:34: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
         where(conditions).find_by(["lower(username) = :value OR lower(email) = :value", { value: login.downcase }])
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  andyw8_user.rb:27:81: C: Metrics/LineLength: Line is too long. [113/80]
+  andyw8_user.rb:29:81: C: Metrics/LineLength: Line is too long. [113/80]
         where(conditions).find_by(['lower(username) = :value OR lower(email) = :value', { value: login.downcase }])
                                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
-  1 file inspected, 7 offenses detected, 4 offenses corrected
+  1 file inspected, 8 offenses detected, 5 offenses corrected
   diff --git i/andyw8_user.rb w/andyw8_user.rb
-  index ba94afe..45b45f6 100644
+  index ba94afe..bea617c 100644
   --- i/andyw8_user.rb
   +++ w/andyw8_user.rb
-  @@ -7,8 +7,8 @@ class User < ApplicationRecord
+  @@ -1,3 +1,5 @@
+  +# frozen_string_literal: true
+  +
+   class User < ApplicationRecord
+     MissingAdminAccount = Class.new(RuntimeError)
+   
+  @@ -7,8 +9,8 @@ class User < ApplicationRecord
      # :confirmable, :lockable, :timeoutable and :omniauthable
      devise :database_authenticatable, :registerable, :confirmable,
             :recoverable, :rememberable, :trackable, :validatable
@@ -71,7 +85,7 @@ rubocop with incorrectable offenses (anyw8 example)
      has_many :blips, through: :radars
    
      attr_accessor :login
-  @@ -24,7 +24,7 @@ class User < ApplicationRecord
+  @@ -24,7 +26,7 @@ class User < ApplicationRecord
      def self.find_for_database_authentication(warden_conditions)
        conditions = warden_conditions.dup
        if (login = conditions.delete(:login))

--- a/test/yapf.t
+++ b/test/yapf.t
@@ -1,0 +1,36 @@
+  $ source "$TESTDIR/helper.sh"
+  If you don't see this, setup failed
+
+yapf
+
+  $ run_restyler yapf crazy.py
+  diff --git i/crazy.py w/crazy.py
+  index 9941de7..4ce75ab 100644
+  --- i/crazy.py
+  +++ w/crazy.py
+  @@ -1,9 +1,19 @@
+  -import math, sys;
+  +import math, sys
+  +
+  +
+   def example1():
+       ####This is a long comment. This should be wrapped to fit within 72 characters.
+  -    some_tuple=(   1,2, 3,'a'  );
+  -    some_variable={'long':'Long code lines should be wrapped within 79 characters.',
+  -    'other':[math.pi, 100,200,300,9876543210,'This is a long string that goes on'],
+  -    'more':{'inner':'This whole logical line should be wrapped.',some_tuple:[1,
+  -    20,300,40000,500000000,60000000000000000]}}
+  +    some_tuple = (1, 2, 3, 'a')
+  +    some_variable = {
+  +        'long':
+  +        'Long code lines should be wrapped within 79 characters.',
+  +        'other': [
+  +            math.pi, 100, 200, 300, 9876543210,
+  +            'This is a long string that goes on'
+  +        ],
+  +        'more': {
+  +            'inner': 'This whole logical line should be wrapped.',
+  +            some_tuple: [1, 20, 300, 40000, 500000000, 60000000000000000]
+  +        }
+  +    }
+       return (some_tuple, some_variable)

--- a/yapf/Dockerfile
+++ b/yapf/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7-alpine
+LABEL maintainer=asottile@umich.edu
+ENV LANG C.UTF-8
+RUN pip install yapf==0.27.0
+WORKDIR /code
+ENTRYPOINT []
+CMD ["yapf", "--help"]

--- a/yapf/info.yaml
+++ b/yapf/info.yaml
@@ -1,0 +1,18 @@
+---
+name: yapf
+image: restyled/restyler-yapf:v0.27.0
+command:
+- yapf
+- "--in-place"
+arguments: []
+include:
+- "**/*.py"
+interpreters:
+- python
+supports_arg_sep: true
+supports_multiple_paths: true
+documentation:
+- https://github.com/google/yapf
+metadata:
+  languages:
+  - Python


### PR DESCRIPTION
I streamed this [over on twitch](https://youtu.be/OaXs501yd90).

This does a bunch of things that were discussed in #29 -- I split them into separate commits to hopefully make it easier to review:

- ignore user configuration for diff prefixes (always use `i/` and `w/`)
- fix make dependencies so test changes cause it to rerun
- use `--shell=bash` so that `cram` works where `sh` is not ~incorrectly bash
- keep intermediate artifacts so `docker build` is called less often
- fix the tests for rubocop (discovered while poking around in CI) -- there were several others that were failing on master or taking ~25 minutes+ to build that I didn't look into (didn't have time for GHC, heh)
- add configuration (and configuration-generation) for testing in travis-ci
- add a few formatters (black, yapf, reorder-python-imports) -- I can add a bunch more I just decided that was enough for today 😆 

In order to start using the CI, you'll need to flip the switch in travis-ci -- travis supports `--volume` with docker which I believe (?) was the thing that wasn't working in circle