### PR TITLE
Update brittany to version 0.12.0.0

### DIFF
--- a/brittany/Dockerfile
+++ b/brittany/Dockerfile
@@ -1,44 +1,50 @@
-FROM fpco/stack-build:lts as builder
+FROM quay.io/haskell_works/stack-build-minimal:18.04 as builder
 MAINTAINER Pat Brisbin <pbrisbin@gmail.com>
-ENV LANG en_US.UTF-8
-ENV PATH /root/.local/bin:$PATH
+RUN stack upgrade
 
 # Dumb cache-buster. Bump this to force a build
-ENV _DOCKERFILE_VERSION 0
+ENV _DOCKERFILE_VERSION 1
 
-ENV BRITTANY_VERSION 0.11.0.0
+ENV BRITTANY_VERSION 0.12.0.0
 RUN \
   git clone https://github.com/lspitzner/brittany.git && cd brittany && \
   git reset --hard "$BRITTANY_VERSION" && \
   stack setup && \
   stack install
 
-FROM fpco/stack-run:lts
+FROM ubuntu:18.04
 MAINTAINER Pat Brisbin <pbrisbin@gmail.com>
-ENV LANG en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8
+RUN \
+  apt-get update && \
+  apt-get -y install \
+    gcc \
+    locales && \
+  locale-gen en_US.UTF-8 && \
+  rm -rf /var/lib/apt/lists/*
 
 # Brittany runtime files
 COPY --from=builder /root/.local/bin/brittany /usr/bin/brittany
 COPY --from=builder \
-  /root/.stack/programs/x86_64-linux/ghc-8.2.2/lib/ghc-8.2.2/settings \
-  /root/.stack/programs/x86_64-linux/ghc-8.2.2/lib/ghc-8.2.2/settings
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/settings \
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/settings
 COPY --from=builder \
-  /root/.stack/programs/x86_64-linux/ghc-8.2.2/lib/ghc-8.2.2/platformConstants \
-  /root/.stack/programs/x86_64-linux/ghc-8.2.2/lib/ghc-8.2.2/platformConstants
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/llvm-targets \
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/llvm-targets
 COPY --from=builder \
-  /root/.stack/programs/x86_64-linux/ghc-8.2.2/lib/ghc-8.2.2/package.conf.d \
-  /root/.stack/programs/x86_64-linux/ghc-8.2.2/lib/ghc-8.2.2/package.conf.d
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/llvm-passes \
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/llvm-passes
+COPY --from=builder \
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/platformConstants \
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/platformConstants
+COPY --from=builder \
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/package.conf.d \
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/package.conf.d
 
 # Needed for CPP
 COPY --from=builder \
-  /root/.stack/programs/x86_64-linux/ghc-8.2.2/lib/ghc-8.2.2/include/ghcversion.h \
-  /root/.stack/programs/x86_64-linux/ghc-8.2.2/lib/ghc-8.2.2/include/ghcversion.h
-
-# Also needed for CPP
-RUN \
-  apt-get update && \
-  apt-get install --assume-yes gcc && \
-  rm -rf /var/lib/apt/lists/*
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/include/ghcversion.h \
+  /root/.stack/programs/x86_64-linux/ghc-8.6.5/lib/ghc-8.6.5/include/ghcversion.h
 
 RUN mkdir -p /code
 WORKDIR /code

--- a/brittany/Dockerfile
+++ b/brittany/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Pat Brisbin <pbrisbin@gmail.com>
 RUN stack upgrade
 
 # Dumb cache-buster. Bump this to force a build
-ENV _DOCKERFILE_VERSION 1
+ENV _DOCKERFILE_VERSION 0
 
 ENV BRITTANY_VERSION 0.12.0.0
 RUN \

--- a/brittany/info.yaml
+++ b/brittany/info.yaml
@@ -1,6 +1,6 @@
 ---
 name: brittany
-image: restyled/restyler-brittany:v0.11.0.0
+image: restyled/restyler-brittany:v0.12.0.0
 command:
 - brittany
 - "--write-mode=inplace"


### PR DESCRIPTION
- Updated to the latest version of `brittany`.
- Switched to using the build and run images used in the `hlint`
  restyler.