### PR TITLE
Use Ubuntu 19.10 (eoan) to have ClangFormat 9.0.0

### DIFF
--- a/clang-format/Dockerfile
+++ b/clang-format/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:19.10
 LABEL maintainer="Pat Brisbin <pbrisbin@gmail.com>"
 ENV LANG en_US.UTF-8
 RUN \

--- a/clang-format/info.yaml
+++ b/clang-format/info.yaml
@@ -1,6 +1,6 @@
 ---
 name: clang-format
-image: restyled/restyler-clang-format:v3.8.0
+image: restyled/restyler-clang-format:v9.0.0
 command:
 - clang-format
 - "-i"

--- a/restylers.yaml
+++ b/restylers.yaml
@@ -58,7 +58,7 @@
   - https://github.com/lspitzner/brittany
   - https://github.com/restyled-io/restyled.io/wiki/Common-Errors:-Brittany
 - name: clang-format
-  image: restyled/restyler-clang-format:v3.8.0
+  image: restyled/restyler-clang-format:v9.0.0
   command:
   - clang-format
   - "-i"


### PR DESCRIPTION
- https://hub.docker.com/_/ubuntu/?tab=tags&page=1&name=19.10
- https://packages.ubuntu.com/eoan/clang-format
- https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormat.html