### PR TITLE
Update Prettier to Version 1.19.1

### DIFF
--- a/prettier/Dockerfile
+++ b/prettier/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:6.9.1
 MAINTAINER Pat Brisbin <pbrisbin@gmail.com>
 ENV LANG en_US.UTF-8
-ENV PRETTIER_VERSION 1.18.2
+ENV PRETTIER_VERSION 1.19.1
 RUN npm install -g "prettier@$PRETTIER_VERSION"
 RUN mkdir -p /code
 WORKDIR /code

--- a/prettier/info.yaml
+++ b/prettier/info.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 name: prettier
-image: restyled/restyler-prettier:v1.18.2
+image: restyled/restyler-prettier:v1.19.1
 command:
   - prettier
   - "--write"

--- a/restylers.yaml
+++ b/restylers.yaml
@@ -245,7 +245,7 @@
     - https://github.com/FriendsOfPHP/PHP-CS-Fixer
 - enabled: true
   name: prettier-markdown
-  image: restyled/restyler-prettier:v1.18.2
+  image: restyled/restyler-prettier:v1.19.1
   command:
     - prettier
     - "--write"
@@ -280,7 +280,7 @@
     - https://github.com/prettier/plugin-ruby
 - enabled: true
   name: prettier-yaml
-  image: restyled/restyler-prettier:v1.18.2
+  image: restyled/restyler-prettier:v1.19.1
   command:
     - prettier
     - "--write"
@@ -296,7 +296,7 @@
     - https://prettier.io/blog/2018/07/29/1.14.0.html
 - enabled: true
   name: prettier
-  image: restyled/restyler-prettier:v1.18.2
+  image: restyled/restyler-prettier:v1.19.1
   command:
     - prettier
     - "--write"


### PR DESCRIPTION
This pull request updates prettier to the latest stable release. This version of the tool formats some JavaScript code a little bit differently.