### PR TITLE
Support multiple files in dotnet-format

### DIFF
--- a/dotnet-format/Dockerfile
+++ b/dotnet-format/Dockerfile
@@ -3,5 +3,5 @@ RUN dotnet tool install -g dotnet-format
 ENV PATH="/root/.dotnet/tools:${PATH}"
 RUN mkdir -p /code
 WORKDIR /code
-#COPY files /
+COPY files /
 CMD ["dotnet", "format", "--help"]

--- a/dotnet-format/files/usr/bin/dotnet-format-files
+++ b/dotnet-format/files/usr/bin/dotnet-format-files
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -eu
+
+is_project=0
+
+for _ in *.csproj; do
+  is_project=1
+done
+
+if ((!is_project)); then
+  echo "Workspace file not found. Exiting."
+  exit
+fi
+
+options=()
+files=()
+
+for arg; do
+  case "$arg" in
+    --)
+      shift
+      files+=("$@")
+      break
+      ;;
+    *)
+      if [ -f "$arg" ]; then
+        files+=("$arg")
+      else
+        options+=("$arg")
+      fi
+      ;;
+  esac
+done
+
+csv_files=$(printf '%s\n' "${files[@]}" | paste -s -d, -)
+echo dotnet format --files="$csv_files" "${options[@]}"
+exec dotnet format --files="$csv_files" "${options[@]}"

--- a/dotnet-format/info.yaml
+++ b/dotnet-format/info.yaml
@@ -1,21 +1,36 @@
 ---
 name: dotnet-format
-version: v0.0.1
+version: v0.0.1-2
 command:
-  - dotnet-format
-  - --files
+  - dotnet-format-files
 include:
   - "**/*.cs"
   - "**/*.vb"
-supports_arg_sep: false
-# It is supported, but only comma separated
-supports_multiple_paths: false
 documentation: ["https://github.com/dotnet/format"]
 metadata:
   languages:
     - C#
     - VB.NET
   tests:
+    # Same file twice, just to exercise --files hack
+    - contents: |
+        int formatted_code;
+            void    unformatted_code  ;
+        void formatted_code_again;
+      restyled: |
+        int formatted_code;
+        void unformatted_code;
+        void formatted_code_again;
+      extension: cs
+      support:
+        path: project.csproj
+        contents: |
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <OutputType>Exe</OutputType>
+              <TargetFramework>netcoreapp3.1</TargetFramework>
+            </PropertyGroup>
+          </Project>
     - contents: |
         int formatted_code;
             void    unformatted_code  ;

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,12 +20,14 @@ class RestylerTests
         support_path = support.fetch("path")
         support_contents = support.fetch("contents")
 
-        if File.exist?(support_path) && File.read(support_path) != support_contents
-          # TODO: figure out a Real Fix here
-          raise "#{name}:#{i} test would clobber #{support_path}. Refusing."
+        if File.exist?(support_path)
+          if File.read(support_path) != support_contents
+            # TODO: figure out a Real Fix here
+            raise "#{name}:#{i} test would clobber #{support_path}. Refusing."
+          end
+        else
+          File.write(support_path, support_contents)
         end
-
-        File.write(support_path, support_contents)
       end
 
       File.write(testfile_path(test, i), test.fetch("contents"))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,7 +62,7 @@ class RestylerTests
     "#{name}-test-#{i}.#{ext}"
   end
 
-  def run_restyler(name, paths)
+  def run_restyler(_name, paths)
     restyler_command = DOCKER_RUN.dup
     restyler_command += %W[--volume #{Dir.pwd}:/code]
     restyler_command << info.fetch("image")
@@ -75,14 +75,14 @@ class RestylerTests
 
     if info.fetch("supports_multiple_paths")
       cmd = restyler_command + paths
-      system(*cmd) or return false
+      system(*cmd) || (return false)
     else
       paths.each do |path|
         cmd = restyler_command + [path]
-        system(*cmd) or return false
+        system(*cmd) || (return false)
       end
     end
 
-    return true
+    true
   end
 end


### PR DESCRIPTION
Add small shim to,

- Accept multiple files (and support [--] separator), then
- Execute with the comma-separate --files argument

And update info.yaml accordingly.