### PR TITLE
Fantamos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - env: RESTYLER=dfmt
     - env: RESTYLER=dotnet-format
     - env: RESTYLER=elm-format
+    - env: RESTYLER=fantomas
     - env: RESTYLER=google-java-format
     - env: RESTYLER=hindent
     - env: RESTYLER=hlint

--- a/fantomas/Dockerfile
+++ b/fantomas/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/core/sdk
+LABEL maintainer="Jozef Hollý <j2.00ghz@gmail.com>"
+ENV PATH="/root/.dotnet/tools:${PATH}"
+ENV FANTAMOS_VERSION=3.3.0
+RUN dotnet tool install \
+  --global fantomas-tool \
+  --version "$FANTAMOS_VERSION"
+RUN mkdir -p /code
+WORKDIR /code
+CMD ["fantomas", "--help"]

--- a/fantomas/info.yaml
+++ b/fantomas/info.yaml
@@ -1,0 +1,57 @@
+---
+enabled: true
+name: fantomas
+version: v3.3.0
+include:
+  - "**/*.fs"
+  - "**/*.fsi"
+  - "**/*.fsx"
+supports_arg_sep: false
+supports_multiple_paths: false
+documentation:
+  - "https://github.com/fsprojects/fantomas"
+metadata:
+  languages:
+    - F#
+  tests:
+    - extension: fs
+      contents: |
+        type Type
+            = TyLam of Type * Type
+            | TyVar of string
+            | TyCon of string * Type list
+            with override this.ToString () =
+                    match this with
+                    | TyLam (t1, t2) -> sprintf "(%s -> %s)" (t1.ToString()) (t2.ToString())
+                    | TyVar a -> a
+                    | TyCon (s, ts) -> s
+      restyled: |
+        type Type =
+            | TyLam of Type * Type
+            | TyVar of string
+            | TyCon of string * Type list
+            override this.ToString() =
+                match this with
+                | TyLam(t1, t2) -> sprintf "(%s -> %s)" (t1.ToString()) (t2.ToString())
+                | TyVar a -> a
+                | TyCon(s, ts) -> s
+    - extension: fs
+      contents: |
+        let Multiple9x9 () =
+            for i in 1 .. 9 do
+                printf "\n";
+                for j in 1 .. 9 do
+                    let k = i * j in
+                    printf "%d x %d = %2d " i j k;
+                done;
+            done;;
+        Multiple9x9 ();;
+      restyled: |
+        let Multiple9x9() =
+            for i in 1 .. 9 do
+                printf "\n"
+                for j in 1 .. 9 do
+                    let k = i * j
+                    printf "%d x %d = %2d " i j k
+
+        Multiple9x9()


### PR DESCRIPTION
Changes:

2314463 (patrick brisbin, 56 seconds ago)
   Fix fantamos test case

   Apparently, the enumeration syntax is not changed by fantamos as the case
   expected. However, the line between blocks and function-call parenthesis
   are being re-formated, so we know the Restyler is functioning.

6bb0a19 (patrick brisbin, 60 seconds ago)
   Disable test case with syntax error

105785d (patrick brisbin, 69 seconds ago)
   All files should end with a newline

a5c6b90 (patrick brisbin, 2 minutes ago)
   Reverse ENV and RUN

   Setting up $PATH before installation prevents a warning about the $PATH 
   being incorrect.

c4899ad (patrick brisbin, 10 minutes ago)
   Fixup info.yaml

   - Fix indentation
   - Remove default-able keys (recent feature)

dfde81e (J2ghz, 3 months ago)
   WIP fantomas