### PR TITLE
"isort" restyler

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -18,6 +18,7 @@ restylers:
   - google-java-format
   #- hindent
   - hlint
+  - isort
   - jdt
   #- jq
   #- ormolu

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - env: RESTYLER=google-java-format
     - env: RESTYLER=hindent
     - env: RESTYLER=hlint
+    - env: RESTYLER=isort
     - env: RESTYLER=jdt
     - env: RESTYLER=ormolu
     - env: RESTYLER=pg_format

--- a/isort/Dockerfile
+++ b/isort/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8-alpine
+LABEL maintainer=sergio@garciparedes.me
+ENV LANG C.UTF-8
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev
+RUN pip install isort==4.3.21
+RUN apk del .build-deps
+WORKDIR /code
+ENTRYPOINT []
+CMD ["isort", "--help"]

--- a/isort/info.yaml
+++ b/isort/info.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 name: isort
-version: 4.3.21
+version: v4.3.21
 include:
   - "**/*.py"
 interpreters:
@@ -42,6 +42,7 @@ metadata:
         from my_lib import Object, Object2, Object3
         from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9,
                                  lib10, lib11, lib12, lib13, lib14, lib15)
+
 
         print("Hey")
         print("yo")

--- a/isort/info.yaml
+++ b/isort/info.yaml
@@ -38,6 +38,7 @@ metadata:
         import sys
 
         from my_lib import Object, Object2, Object3
+        from third_party import lib3
 
         print("Hey")
         print("yo")

--- a/isort/info.yaml
+++ b/isort/info.yaml
@@ -23,6 +23,8 @@ metadata:
 
         import sys
 
+        from third_party import lib15, lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9, lib10, lib11, lib12, lib13, lib14
+
         import sys
 
         from __future__ import absolute_import
@@ -38,7 +40,8 @@ metadata:
         import sys
 
         from my_lib import Object, Object2, Object3
-        from third_party import lib3
+        from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9,
+                                 lib10, lib11, lib12, lib13, lib14, lib15)
 
         print("Hey")
         print("yo")

--- a/isort/info.yaml
+++ b/isort/info.yaml
@@ -43,6 +43,5 @@ metadata:
         from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9,
                                  lib10, lib11, lib12, lib13, lib14, lib15)
 
-
         print("Hey")
         print("yo")

--- a/isort/info.yaml
+++ b/isort/info.yaml
@@ -23,8 +23,6 @@ metadata:
 
         import sys
 
-        from third_party import lib15, lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9, lib10, lib11, lib12, lib13, lib14
-
         import sys
 
         from __future__ import absolute_import
@@ -40,8 +38,6 @@ metadata:
         import sys
 
         from my_lib import Object, Object2, Object3
-        from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9,
-                                 lib10, lib11, lib12, lib13, lib14, lib15)
 
         print("Hey")
         print("yo")

--- a/isort/info.yaml
+++ b/isort/info.yaml
@@ -1,0 +1,48 @@
+---
+enabled: true
+name: isort
+version: 4.3.21
+include:
+  - "**/*.py"
+interpreters:
+  - python
+documentation:
+  - https://github.com/timothycrosley/isort/
+metadata:
+  languages:
+    - Python
+  tests:
+    - contents: |
+        from my_lib import Object
+
+        import os
+
+        from my_lib import Object3
+
+        from my_lib import Object2
+
+        import sys
+
+        from third_party import lib15, lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9, lib10, lib11, lib12, lib13, lib14
+
+        import sys
+
+        from __future__ import absolute_import
+
+        from third_party import lib3
+
+        print("Hey")
+        print("yo")
+      restyled: |
+        from __future__ import absolute_import
+
+        import os
+        import sys
+
+        from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8,
+                                 lib9, lib10, lib11, lib12, lib13, lib14, lib15)
+
+        from my_lib import Object, Object2, Object3
+
+        print("Hey")
+        print("yo")

--- a/isort/info.yaml
+++ b/isort/info.yaml
@@ -39,8 +39,8 @@ metadata:
         import os
         import sys
 
-        from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8,
-                                 lib9, lib10, lib11, lib12, lib13, lib14, lib15)
+        from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9,
+                                 lib10, lib11, lib12, lib13, lib14, lib15)
 
         from my_lib import Object, Object2, Object3
 

--- a/isort/info.yaml
+++ b/isort/info.yaml
@@ -39,10 +39,9 @@ metadata:
         import os
         import sys
 
+        from my_lib import Object, Object2, Object3
         from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9,
                                  lib10, lib11, lib12, lib13, lib14, lib15)
-
-        from my_lib import Object, Object2, Object3
 
         print("Hey")
         print("yo")

--- a/restylers.yaml
+++ b/restylers.yaml
@@ -186,6 +186,20 @@
     - https://github.com/ndmitchell/hlint#readme
     - https://github.com/restyled-io/restyled.io/wiki/Common-Errors:-HLint
 - enabled: false
+  name: isort
+  image: restyled/restyler-isort:4.3.21
+  command:
+    - isort
+  arguments: []
+  include:
+    - "**/*.py"
+  interpreters:
+    - python
+  supports_arg_sep: true
+  supports_multiple_paths: true
+  documentation:
+    - https://github.com/timothycrosley/isort
+- enabled: false
   name: jdt
   image: restyled/restyler-jdt:v2.10.0
   command:


### PR DESCRIPTION
This pull request resolves the following issue:
* isort #71

The applied changes includes the `Dockerfile` and the needed setup files to add a new restyler, based on the current `black` setup.

About the way to generate the docker image, I've don't know if it's autogenerated during the build of `master` branch of this repo or I need to generate my own or the project maintainers will generate it. Could you explain me how to do that?  Related with that, do I need to perform more changes over another repo?
