### PR TITLE
chore(prettier): Include supported file extensions

### DIFF
--- a/prettier/info.yaml
+++ b/prettier/info.yaml
@@ -22,6 +22,17 @@ documentation:
 metadata:
   languages:
     - JavaScript
+    - JSX
+    - Angular
+    - Vue
+    - Flow
+    - TypeScript
+    - CSS, Less, and SCSS
+    - HTML
+    - JSON
+    - GraphQL
+    - Markdown, including GFM and MDX
+    - YAML
   tests:
     - extension: js
       contents: |

--- a/prettier/info.yaml
+++ b/prettier/info.yaml
@@ -8,6 +8,15 @@ command:
 include:
   - "**/*.js"
   - "**/*.jsx"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.ng"
+  - "**/*.hbs"
+  - "**/*.vue"
+  - "**/*.mjml"
+  - "**/*.less"
+  - "**/*.scss"
+  - "**/*.graphql"
 documentation:
   - https://prettier.io/docs/en/
 metadata:


### PR DESCRIPTION
[Prettier](https://prettier.io/docs/en/index.html) supports more file extensions than are configured. This expands to [all supported file extensions](https://github.com/fisker/prettier/blob/master/tests_config/utils/check-parsers.js).

## Extension exceptions (because of conflict with other restylers):
- JSON (handled by [prettier-json](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers#prettier-json))
- YAML (handled by [prettier-yaml](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers#prettier-yaml))
- Ruby (handled by [prettier-json](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers#prettier-ruby))
- Markdown (handled by [prettier-markdown](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers#prettier-markdown))
- CSS (conflicts with [jdt](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers#jdt))
- HTML (conflicts with [jdt](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers#jdt))