### PR TITLE
Use Ubuntu 20.04 (focal) to have ClangFormat 10.0.0

### DIFF
--- a/clang-format/Dockerfile
+++ b/clang-format/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 LABEL maintainer="Pat Brisbin <pbrisbin@gmail.com>"
 ENV LANG en_US.UTF-8
 RUN \

--- a/clang-format/info.yaml
+++ b/clang-format/info.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 name: clang-format
-version: v9.0.0
+version: v10.0.0
 command:
   - clang-format
   - "-i"

--- a/restylers.yaml
+++ b/restylers.yaml
@@ -72,7 +72,7 @@
     - https://github.com/restyled-io/restyled.io/wiki/Common-Errors:-Brittany
 - enabled: true
   name: clang-format
-  image: restyled/restyler-clang-format:v9.0.0
+  image: restyled/restyler-clang-format:v10.0.0
   command:
     - clang-format
     - "-i"


### PR DESCRIPTION
Hi

I am trying to integrate restyled.io service into ncnn project
But our coding style depends some new options introduced in clang-format 10.0
Let's update it

https://github.com/Tencent/ncnn/pull/1840


https://packages.ubuntu.com/focal/clang-format
