### PR TITLE
Upgrade black to v20.8b1

### DIFF
--- a/black/Dockerfile
+++ b/black/Dockerfile
@@ -3,9 +3,9 @@ LABEL maintainer=asottile@umich.edu
 ENV LANG C.UTF-8
 RUN \
   apk add --no-cache --virtual .build-deps \
-    gcc=9.3.0-r0 \
-    musl-dev=1.1.24-r2 && \
-  pip install black==19.10b0 && \
+    gcc=9.3.0-r2 \
+    musl-dev=1.1.24-r9 && \
+  pip install black==20.8b1 && \
   apk del .build-deps
 WORKDIR /code
 ENTRYPOINT []

--- a/black/info.yaml
+++ b/black/info.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 name: black
-version: v19.10b0-3
+version: v20.8b1
 include:
   - "**/*.py"
 interpreters:


### PR DESCRIPTION
`black` had a new release yesterday: https://github.com/psf/black/releases/tag/20.8b1

Btw, are there any plans to auto-update them? Idk, maybe use renovate to update from requirements.txt or package.json?