### PR TITLE
chore: Update reorder-python-imports version to 2.3.6

### DIFF
--- a/restylers/reorder-python-imports/Dockerfile
+++ b/restylers/reorder-python-imports/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-alpine
 LABEL maintainer=asottile@umich.edu
 ENV LANG C.UTF-8
-RUN pip install reorder-python-imports==2.3.6
+RUN pip install --no-cache-dir reorder-python-imports==2.3.6
 WORKDIR /code
 ENTRYPOINT []
 CMD ["reorder-python-imports", "--help"]

--- a/restylers/reorder-python-imports/Dockerfile
+++ b/restylers/reorder-python-imports/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-alpine
 LABEL maintainer=asottile@umich.edu
 ENV LANG C.UTF-8
-RUN pip install reorder-python-imports==1.6.0
+RUN pip install reorder-python-imports==2.3.6
 WORKDIR /code
 ENTRYPOINT []
 CMD ["reorder-python-imports", "--help"]

--- a/restylers/reorder-python-imports/info.yaml
+++ b/restylers/reorder-python-imports/info.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 name: reorder-python-imports
-version: v1.6.0
+version: v2.3.6
 command:
   - reorder-python-imports
   - "--exit-zero-even-if-changed"


### PR DESCRIPTION
It seems that reorder-python-imports has had several updates this year: https://github.com/asottile/reorder_python_imports/releases. I unfortunately experienced v1.6.0 failing to process a file, but the latest version seems to be OK with it, so I thought I would help update the version :smile:. Thanks for your hard work!