### PR TITLE
Add Standard Ruby Restyler

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -48,6 +48,7 @@ jobs:
           - rustfmt
           - shellharden
           - shfmt
+          - standardrb
           - stylish-haskell
           - terraform
           - whitespace

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,6 +47,7 @@ jobs:
           - rustfmt
           - shellharden
           - shfmt
+          - standardrb
           - stylish-haskell
           - terraform
           - whitespace

--- a/rubocop/info.yaml
+++ b/rubocop/info.yaml
@@ -1,5 +1,5 @@
 ---
-enabled: true
+enabled: false
 name: rubocop
 version_cmd: |
   cd /app &&  bundle info rubocop | sed '/.*rubocop (\(.*\))$/!d; s//v\1/'

--- a/standardrb/Dockerfile
+++ b/standardrb/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.7.2-alpine3.13
+LABEL maintainer="Pat Brisbin <pbrisbin@gmail.com>"
+ENV LANG en_US.UTF-8
+RUN apk add --no-cache \
+  bash=5.1.0-r0 \
+  g++=10.2.1_pre1-r3 \
+  linux-headers=5.7.8-r0 \
+  make=4.3-r0
+RUN mkdir -p /app
+WORKDIR /app
+COPY Gemfile .
+RUN bundle
+RUN bundle binstubs standard
+ENV PATH=/app/bin:$PATH
+RUN mkdir -p /code
+WORKDIR /code
+ENTRYPOINT []
+CMD ["standardrb", "--help"]

--- a/standardrb/Gemfile
+++ b/standardrb/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'standard', '1.0.1'

--- a/standardrb/info.yaml
+++ b/standardrb/info.yaml
@@ -1,0 +1,27 @@
+---
+enabled: true
+name: standardrb
+version_cmd: |
+  cd /app &&  bundle info standard | sed '/.*standard (\(.*\))$/!d; s//v\1/'
+command:
+  - standardrb
+  - "--fix"
+include:
+  - "**/*.rb"
+interpreters:
+  - ruby
+documentation:
+  - https://github.com/testdouble/standard
+metadata:
+  languages:
+    - Ruby
+  tests:
+    - extension: rb
+      contents: |
+        def some_method
+            do_something
+        end
+      restyled: |
+        def some_method
+          do_something
+        end


### PR DESCRIPTION
:thinking: I don't know that this and Rubocop should both be on by default.
Restyled loves the no-configuration philosophy, so I would prefer Standard Ruby
in a vacuum, but since we already have Rubcop there are compatibility concerns.