### PR TITLE
Attempt to disable layer-caching by restyler

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -53,16 +53,14 @@ jobs:
           - terraform
           - whitespace
           - yapf
-        layer-caching:
-          - true
         include:
           - restyler: hlint
-            layer-caching: false
+            disable-layer-caching: true
 
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        if: ${{ matrix.layer-caching }}
+        if: ${{ ! matrix.disabl-layer-caching }}
         continue-on-error: true
         with:
           key: docker-layer-caching-${{ matrix.restyler }}-{hash}

--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -55,9 +55,9 @@ jobs:
           - yapf
         layer-caching:
           - true
-      include:
-        - restyler: hlint
-          layer-caching: false
+        include:
+          - restyler: hlint
+            layer-caching: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        if: ${{ ! matrix.disabl-layer-caching }}
+        if: ${{ ! matrix.disable-layer-caching }}
         continue-on-error: true
         with:
           key: docker-layer-caching-${{ matrix.restyler }}-{hash}

--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -53,10 +53,16 @@ jobs:
           - terraform
           - whitespace
           - yapf
+        layer-caching:
+          - true
+      include:
+        - restyler: hlint
+          layer-caching: false
 
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
+        if: ${{ matrix.layer-caching }}
         continue-on-error: true
         with:
           key: docker-layer-caching-${{ matrix.restyler }}-{hash}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,9 +54,9 @@ jobs:
           - yapf
         layer-caching:
           - true
-      include:
-        - restyler: hlint
-          layer-caching: false
+        include:
+          - restyler: hlint
+            layer-caching: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,16 +52,14 @@ jobs:
           - terraform
           - whitespace
           - yapf
-        layer-caching:
-          - true
         include:
           - restyler: hlint
-            layer-caching: false
+            disable-layer-caching: true
 
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        if: ${{ matrix.layer-caching }}
+        if: ${{ ! matrix.disable-layer-caching }}
         continue-on-error: true
         with:
           key: docker-layer-caching-${{ matrix.restyler }}-{hash}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,10 +52,16 @@ jobs:
           - terraform
           - whitespace
           - yapf
+        layer-caching:
+          - true
+      include:
+        - restyler: hlint
+          layer-caching: false
 
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
+        if: ${{ matrix.layer-caching }}
         continue-on-error: true
         with:
           key: docker-layer-caching-${{ matrix.restyler }}-{hash}


### PR DESCRIPTION
Unfortunately the very Restylers that would benefit most from layer caching,
fail with out of space errors in the Post Run step. For now, we want to disable
such Jobs from this caching. It'll be much slower, but hopefully succeed.