### PR TITLE
clang-format: bump to llvm 15 toolchain

### DIFF
--- a/clang-format/Dockerfile
+++ b/clang-format/Dockerfile
@@ -5,14 +5,14 @@ RUN \
   apt-get update -y && \
   apt-get install -y --no-install-recommends ca-certificates gnupg2 wget && \
   { \
-    echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"; \
-    echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"; \
+    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"; \
+    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"; \
   } >>/etc/apt/sources.list && \
   wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
   apt-get update -y && \
-  apt-get install -y --no-install-recommends clang-format-13 && \
+  apt-get install -y --no-install-recommends clang-format-15 && \
   rm -rf /var/lib/apt/lists/*
-RUN ln -s /usr/bin/clang-format-13 /usr/bin/clang-format
+RUN ln -s /usr/bin/clang-format-15 /usr/bin/clang-format
 RUN mkdir -p /code
 WORKDIR /code
 ENTRYPOINT []


### PR DESCRIPTION
Bumps clang-format to LLVM 15.
Fixes the APT repository to match Ubuntu 22.04 as used in the Dockerfile.