### PR TITLE
Update Fourmolu, use pre-built binaries

### DIFF
--- a/fourmolu/Dockerfile
+++ b/fourmolu/Dockerfile
@@ -1,40 +1,20 @@
-FROM restyled/stack-build-minimal:22.04 as builder
-LABEL maintainer="Tristan de Cacqueray <tdecacqu@redhat.com>"
-RUN stack upgrade
-
-COPY stack.yaml /root/.stack/global-project/stack.yaml
-RUN stack install fourmolu
-
-# The following support files' locations are brittle. Use this RUN command to
-# re-discover them when we update anything.
-# RUN find /root/.stack/programs/x86_64-linux \
-#   \( \
-#     -name settings -o \
-#     -name platformConstants -o \
-#     -name llvm-targets -o \
-#     -name llvm-passes -o \
-#     -name package.conf.d \
-#   \) \
-#   -printf "COPY --from=builder %p %p\n"
-# RUN exit 1
-
 FROM ubuntu:22.04
 LABEL maintainer="Tristan de Cacqueray <tdecacqu@redhat.com>"
 ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8
 RUN \
   apt-get update && \
   apt-get --no-install-recommends -y install \
+    ca-certificates \
+    curl \
     locales && \
   locale-gen en_US.UTF-8 && \
   rm -rf /var/lib/apt/lists/*
 ENV LANG=en_US.UTF-8
-# BEGIN copy from RUN-find
-COPY --from=builder /root/.stack/programs/x86_64-linux/ghc-tinfo6-9.4.3/lib/ghc-9.4.3/lib/llvm-passes /root/.stack/programs/x86_64-linux/ghc-tinfo6-9.4.3/lib/ghc-9.4.3/lib/llvm-passes
-COPY --from=builder /root/.stack/programs/x86_64-linux/ghc-tinfo6-9.4.3/lib/ghc-9.4.3/lib/settings /root/.stack/programs/x86_64-linux/ghc-tinfo6-9.4.3/lib/ghc-9.4.3/lib/settings
-COPY --from=builder /root/.stack/programs/x86_64-linux/ghc-tinfo6-9.4.3/lib/ghc-9.4.3/lib/llvm-targets /root/.stack/programs/x86_64-linux/ghc-tinfo6-9.4.3/lib/ghc-9.4.3/lib/llvm-targets
-COPY --from=builder /root/.stack/programs/x86_64-linux/ghc-tinfo6-9.4.3/lib/ghc-9.4.3/lib/package.conf.d /root/.stack/programs/x86_64-linux/ghc-tinfo6-9.4.3/lib/ghc-9.4.3/lib/package.conf.d
-# END copy from RUN-find
-COPY --from=builder /root/.local/bin/fourmolu /usr/bin/fourmolu
+ENV FOURMOLU_VERSION=0.12.0.0
+RUN \
+  curl -L -o /usr/bin/fourmolu \
+  https://github.com/fourmolu/fourmolu/releases/download/v${FOURMOLU_VERSION}/fourmolu-${FOURMOLU_VERSION}-linux-x86_64 && \
+  chmod +x /usr/bin/fourmolu
 RUN mkdir -p /code
 WORKDIR /code
 ENTRYPOINT []

--- a/fourmolu/info.yaml
+++ b/fourmolu/info.yaml
@@ -1,4 +1,3 @@
----
 enabled: false
 name: fourmolu
 version_cmd: |
@@ -10,6 +9,7 @@ command:
 include:
   - "**/*.hs"
 documentation:
+  - https://fourmolu.github.io/
   - https://github.com/fourmolu/fourmolu
 metadata:
   upstream:


### PR DESCRIPTION
The project has started hosting binaries in its releases. This means we
don't have to build it, which is both simpler and means we can use
the latest version without figuring out a ghc-9.6 build to produce it.

I'm assuming that a Fourmolu built with newer GHC can still reformat
code targeting an older GHC, but not necessarily the reverse. This
should make it safe (and best) to use the latest version we can to cover
the widest range of projects we can.