### PR TITLE
Pre-install tailwindcss and yarn-link it

### DIFF
--- a/prettier/Dockerfile
+++ b/prettier/Dockerfile
@@ -4,9 +4,11 @@ ENV LANG en_US.UTF-8
 RUN mkdir -p /app
 WORKDIR /app
 COPY package.json .
-RUN npm install
+RUN yarn install
+RUN cd node_modules/tailwindcss && yarn link
 ENV PATH=/app/node_modules/.bin:$PATH
+COPY prettier-with-tailwindcss /usr/local/bin/prettier-with-tailwindcss
 RUN mkdir -p /code
 WORKDIR /code
 ENTRYPOINT []
-CMD ["prettier", "--help"]
+CMD ["prettier-with-tailwindcss", "--help"]

--- a/prettier/info.yaml
+++ b/prettier/info.yaml
@@ -16,7 +16,26 @@ metadata:
   languages:
     - JavaScript
   tests:
-    - extension: js
+    - name: Matrix example
+      extension: js
+      contents: |
+        matrix(
+          1, 0, 0,
+          0, 1, 0,
+          0, 0, 1
+        )
+      restyled: |
+        matrix(1, 0, 0, 0, 1, 0, 0, 0, 1);
+    - name: With tailwindcss config
+      support:
+        path: tailwind.config.js
+        contents: |
+          const defaultTheme = require('tailwindcss/defaultTheme')
+
+          module.exports = {
+            ...defaultTheme,
+          }
+      extension: js
       contents: |
         matrix(
           1, 0, 0,

--- a/prettier/info.yaml
+++ b/prettier/info.yaml
@@ -2,9 +2,9 @@
 enabled: true
 name: prettier
 version_cmd: |
-  prettier --version | sed 's/^/v/; s/$/-1/'
+  prettier --version | sed 's/^/v/; s/$/-2/'
 command:
-  - prettier
+  - prettier-with-tailwindcss
   - "--write"
 include:
   - "**/*.js"

--- a/prettier/package.json
+++ b/prettier/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "prettier": "2.8.8",
-    "prettier-plugin-tailwindcss": "^0.3.0"
+    "prettier-plugin-tailwindcss": "^0.3.0",
+    "tailwindcss": "^3.3.2"
   }
 }

--- a/prettier/prettier-with-tailwindcss
+++ b/prettier/prettier-with-tailwindcss
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+yarn link tailwindcss
+trap 'yarn unlink tailwindcss' EXIT
+prettier "$@"


### PR DESCRIPTION
Apparently,

1. We need more than the plugin to use e.g. `tailwindcss/defaultTheme`
2. We need to do some `yarn link` shenanigans to make it available
