### PR TITLE
clang-format: bump to llvm 16 toolchain

### DIFF
--- a/clang-format/Dockerfile
+++ b/clang-format/Dockerfile
@@ -5,14 +5,14 @@ RUN \
   apt-get update -y && \
   apt-get install -y --no-install-recommends ca-certificates gnupg2 wget && \
   { \
-    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"; \
-    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"; \
+    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"; \
+    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"; \
   } >>/etc/apt/sources.list && \
   wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
   apt-get update -y && \
-  apt-get install -y --no-install-recommends clang-format-15 && \
+  apt-get install -y --no-install-recommends clang-format-16 && \
   rm -rf /var/lib/apt/lists/*
-RUN ln -s /usr/bin/clang-format-15 /usr/bin/clang-format
+RUN ln -s /usr/bin/clang-format-16 /usr/bin/clang-format
 RUN mkdir -p /code
 WORKDIR /code
 ENTRYPOINT []


### PR DESCRIPTION
I didn't find any documentation/policy on when restylers are to be updated, so I just went ahead to create the PR to update clang-format from v15 to v16, released 2023-03-18 (https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.0).

In general since major clang-format releases break config-files and formatting, it might be benefiticial to support different versions of clang-format at the same time. I know it's possible now in different ways (pinning the restylers version or pinning the restyler's image in its configuration)  but these are quite tedious since to look up the correct version or image coordinates. Ideally I'd like to enable clang-format-16 in my restyler config and switch to 17 once it is released and the code is in a stage where I can afford a full reformat.

But this is more an ease of use point, just having clang-format-16 in would already help a lot!

Thanks for your work on restyled we really enjoy using it!