### PR TITLE
Initial pre-commit restyler

### DIFF
--- a/pre-commit/Dockerfile
+++ b/pre-commit/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-alpine
+LABEL maintainer=asottile@umich.edu
+ENV LANG C.UTF-8
+RUN apk add --no-cache bash git
+
+RUN mkdir /app
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir --requirement requirements.txt
+
+COPY config.yaml /app/.pre-commit-config.yaml
+RUN git init && pre-commit install-hooks && rm -rf .git
+
+WORKDIR /code
+COPY validate /usr/local/bin/validate-pre-commit
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["black", "--help"]

--- a/pre-commit/config.yaml
+++ b/pre-commit/config.yaml
@@ -1,0 +1,18 @@
+# This file defines what hooks we pre-install into the Restyler image. Only
+# these hooks will be available and users configured with any other
+# hooks/revisions will receive an error.
+#
+# If updating this to add new hooks, be sure to also install any required system
+# dependencies in the Dockerfile. At the moment, it's python-focused.
+#
+repos:
+  - repo: https://github.com/python/black
+    rev: "23.7.0"
+    hooks:
+      - id: black
+      - id: black-jupyter
+  - repo: https://github.com/python/black
+    rev: "23.3.0"
+    hooks:
+      - id: black
+      - id: black-jupyter

--- a/pre-commit/entrypoint.sh
+++ b/pre-commit/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -d .git ]]; then
+  cat >&2 <<'EOM'
+[WARNING] Auto-initializing current directory as a git repository
+
+This is required for pre-commit to function. If this is not a test system, where
+auto-initializing like this is expected, something may be wrong.
+
+EOM
+  git init --quiet
+fi
+
+validate-pre-commit
+exec "$@"

--- a/pre-commit/info.yaml
+++ b/pre-commit/info.yaml
@@ -10,7 +10,7 @@ include:
   - "**/*"
 supports_arg_sep: false
 documentation:
-  - 'https://pre-commit.com'
+  - "https://pre-commit.com"
 metadata:
   languages:
     - "*"

--- a/pre-commit/info.yaml
+++ b/pre-commit/info.yaml
@@ -1,0 +1,66 @@
+enabled: false
+name: pre-commit
+version_cmd: |
+  pip show pre-commit | sed '/^Version: \(.*\)$/!d; s//v\1/'
+command:
+  - pre-commit
+  - run
+  - --files
+include:
+  - "**/*"
+supports_arg_sep: false
+documentation:
+  - 'https://pre-commit.com'
+metadata:
+  languages:
+    - "*"
+  tests:
+    - support:
+        path: .pre-commit-config.yaml
+        contents: |
+          repos:
+            - repo: https://github.com/python/black
+              rev: "23.7.0"
+              hooks:
+                - id: black
+
+      # Copied from black/info.yaml
+      name: black
+      extension: py
+      contents: |
+        import math, sys;
+        def example1():
+            ####This is a long comment. This should be wrapped to fit within 72 characters.
+            some_tuple=(   1,2, 3,'a'  );
+            some_variable={'long':'Long code lines should be wrapped within 79 characters.',
+            'other':[math.pi, 100,200,300,9876543210,'This is a long string that goes on'],
+            'more':{'inner':'This whole logical line should be wrapped.',some_tuple:[1,
+            20,300,40000,500000000,60000000000000000]}}
+            return (some_tuple, some_variable)
+
+      # NB. This file was reused from the autopep8 tests, so some of the things
+      # it states within itself (such as wrapping the comment) aren't actually
+      # handled by black
+      restyled: |
+        import math, sys
+
+
+        def example1():
+            ####This is a long comment. This should be wrapped to fit within 72 characters.
+            some_tuple = (1, 2, 3, "a")
+            some_variable = {
+                "long": "Long code lines should be wrapped within 79 characters.",
+                "other": [
+                    math.pi,
+                    100,
+                    200,
+                    300,
+                    9876543210,
+                    "This is a long string that goes on",
+                ],
+                "more": {
+                    "inner": "This whole logical line should be wrapped.",
+                    some_tuple: [1, 20, 300, 40000, 500000000, 60000000000000000],
+                },
+            }
+            return (some_tuple, some_variable)

--- a/pre-commit/requirements.txt
+++ b/pre-commit/requirements.txt
@@ -1,0 +1,2 @@
+pre-commit==3.3.3
+PyYAML==6.0.1

--- a/pre-commit/validate
+++ b/pre-commit/validate
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+import os
+import sys
+import yaml
+
+HAVES_PATH = "/app/.pre-commit-config.yaml"
+WANTS_PATH = ".pre-commit-config.yaml"
+ISSUES_URL = "https://github.com/restyled-io/restylers/issues/new"
+PR_URL = "https://github.com/restyled-io/restylers/TODO"
+
+
+def die(msg):
+    print("Unable to run pre-commit: {}".format(msg), file=sys.stderr)
+    exit(1)
+
+
+if not os.path.isfile(WANTS_PATH):
+    die("{} must exist".format(WANTS_PATH))
+
+
+def get_config_repos(io):
+    return list(map(simplify, yaml.safe_load(io).get("repos")))
+
+
+def simplify(repo):
+    return "{}@{}".format(repo.get("repo"), repo.get("rev"))
+
+
+with open(HAVES_PATH, "r") as io:
+    haves = get_config_repos(io)
+    haves.sort()
+
+
+with open(WANTS_PATH, "r") as io:
+    wants = get_config_repos(io)
+    wants.sort()
+
+
+missing = []
+
+for want in wants:
+    if (not want in haves):
+        missing.append(want)
+
+if missing:
+  die("""required hook not installed
+
+Any pre-commit hooks must be pre-installed because we do not allow restyler
+images to make network requests to install them on-demand.
+
+The available hooks are:
+- {}
+
+You are using the following hooks, which are not available:
+- {}
+
+To request your hook be pre-installed, please open an Issue at:
+{}
+
+To open a PR adding the hook yourself, see:
+{}
+
+""".format("\n- ".join(haves), "\n- ".join(missing), ISSUES_URL, PR_URL))


### PR DESCRIPTION
`pre-commit` refuses to run unless in a git repository, which seems like
something that could be avoided for commands that don't interact with
git, like `install-hooks` and `run`. I could find no way around this,
and it's usually the case under normal operation that we'll be in a git
repository anyway, so I didn't want to do too much to work around it
(e.g. forking). Instead, I added a custom entrypoint that initializes
git if necessary.

We pre-install a very limited set of hooks right now. We cannot rely on
the behavior of installing hooks lazily because restylers don't have
network. But we can pre-install whatever we want during the docker
build. As of this commit, we only pre-install two versions of black.
This is just enough to prove things function, and that multiple versions
of the same hook can co-exist and be used by users, which I was worried
about.

Obviously, this is not useful yet compared to just using our black
restyler, but hopefully it's now obvious and trivial to extend it such
that it is. I'm hoping a pre-commit user could take it from here to
decide on a set of hooks and revisions that we should launch with.

NOTE: since this is such a picky auto-formatter, and it operates on
files of any extension, I think it will always be an `enabled:false`,
opt-in restyler.
