### PR TITLE
cmake-format: include optional PyYAML dependency

### DIFF
--- a/cmake-format/info.yaml
+++ b/cmake-format/info.yaml
@@ -1,7 +1,7 @@
 enabled: true
 name: cmake-format
 version_cmd: |
-  cmake-format --version
+  cmake-format --version | sed 's/$/-1/' # add local version bump to redeploy
 command:
   - cmake-format
   - --in-place

--- a/cmake-format/requirements.txt
+++ b/cmake-format/requirements.txt
@@ -1,1 +1,2 @@
 cmakelang==0.6.13
+pyyaml>=5.3


### PR DESCRIPTION
PyYAML is an optional dependency of cmake-format, which means that it will not automatically be installed but triggers import errors if a `cmake-format.yaml` file is present in the project. It seems that PyYAML seems to have been included in the base image before so that this did not cause problems.

This optional dependency is also described in cmake-format's [install documentation](https://cmake-format.readthedocs.io/en/latest/installation.html), second blue box.

The versions for the dependency are taken from cmake-format's own [setup.py](https://github.com/cheshirekow/cmake_format/blob/eff5df1f41c665ea7cac799396042e4f406ef09a/cmakelang/pypi/setup.py#L59)

Project with restyler error: https://restyled.io/gh/fair-acc/repos/opendigitizer/jobs/3493880
Previous successful run: https://restyled.io/gh/fair-acc/repos/opendigitizer/jobs/3445580

I hope I diagnosed this correctly and it is not again just a configuration error on my side.