### PR TITLE
Correct multiple-path handling in pyment

### DIFF
--- a/pyment/info.yaml
+++ b/pyment/info.yaml
@@ -5,6 +5,7 @@ version_cmd: |
 command:
   - pyment
   - -w
+supports_multiple_paths: false
 include:
   - "**/*.py"
 interpreters:
@@ -15,6 +16,52 @@ metadata:
   languages:
     - Python
   tests:
+    - contents: |
+        def func(param1=True, param2: str = 'default val'):
+          '''Description of func with docstring groups style.
+
+          Params:
+              param1 - descr of param1 that has True for default value.
+              param2 - descr of param2
+
+          Returns:
+              some value
+
+          Raises:
+              keyError: raises key exception
+              TypeError: raises type exception
+
+          '''
+          pass
+
+        class A:
+            def method(self, param1, param2=None) -> int:
+                pass
+
+      restyled: |
+        def func(param1=True, param2: str = 'default val'):
+            """Description of func with docstring groups style.
+
+            :param param1: descr of param1 that has True for default value
+            :param param2: descr of param2
+            :param param2: str:  (Default value = 'default val')
+            :returns: some value
+            :raises keyError: raises key exception
+            :raises TypeError: raises type exception
+
+            """
+          pass
+
+        class A:
+            """ """
+            def method(self, param1, param2=None) -> int:
+                """
+
+                :param param1: 
+                :param param2:  (Default value = None)
+
+                """
+                pass
     - contents: |
         def func(param1=True, param2: str = 'default val'):
           '''Description of func with docstring groups style.


### PR DESCRIPTION
It looks like `pyment` usage is one path at a time, so when multiple
files are restyled at once, it fails. We can address this by setting
`supports_multiple_paths` to `false`, causing Restyler to run it once
per path. And we duplicate the existing test case to trigger the bug
before fixing it. We should probably ensure all restylers have more than
1 test case, but I'm deferring that for now.
