### PR TITLE
clang-format: bump to llvm 17 toolchain

### DIFF
--- a/clang-format/Dockerfile
+++ b/clang-format/Dockerfile
@@ -5,14 +5,14 @@ RUN \
   apt-get update -y && \
   apt-get install -y --no-install-recommends ca-certificates gnupg2 wget && \
   { \
-    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"; \
-    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"; \
+    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"; \
+    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"; \
   } >>/etc/apt/sources.list && \
   wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
   apt-get update -y && \
-  apt-get install -y --no-install-recommends clang-format-16 && \
+  apt-get install -y --no-install-recommends clang-format-17 && \
   rm -rf /var/lib/apt/lists/*
-RUN ln -s /usr/bin/clang-format-16 /usr/bin/clang-format
+RUN ln -s /usr/bin/clang-format-17 /usr/bin/clang-format
 RUN mkdir -p /code
 WORKDIR /code
 ENTRYPOINT []


### PR DESCRIPTION
This is not the newest release, see https://releases.llvm.org/, but
a) I didn't want to switch to a version that's not yet packaged in the latest ubuntu release (23.10) and
b) skipping the release alltogether would prevent to specify the v17 version tag in the restyled.yml

I'll do a new PR once clang-format-18 is available in more common repos.

previous bump for reference: #549