### PR TITLE
clang-format: bump to llvm 18 toolchain

### DIFF
--- a/clang-format/Dockerfile
+++ b/clang-format/Dockerfile
@@ -5,14 +5,14 @@ RUN \
   apt-get update -y && \
   apt-get install -y --no-install-recommends ca-certificates gnupg2 wget && \
   { \
-    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"; \
-    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"; \
+    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"; \
+    echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"; \
   } >>/etc/apt/sources.list && \
   wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
   apt-get update -y && \
-  apt-get install -y --no-install-recommends clang-format-17 && \
+  apt-get install -y --no-install-recommends clang-format-18 && \
   rm -rf /var/lib/apt/lists/*
-RUN ln -s /usr/bin/clang-format-17 /usr/bin/clang-format
+RUN ln -s /usr/bin/clang-format-18 /usr/bin/clang-format
 RUN mkdir -p /code
 WORKDIR /code
 ENTRYPOINT []


### PR DESCRIPTION
Use the latest released clang-format-18 version.

Note that in the ubuntu world this is for now only available in the noble development version, so projects that have a contribution forkflow that requires contributors to run formatting locally should probably explicitly opt for an older version (see #550).