### PR TITLE
Stop relying on SDK for promote

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          sparse-checkout: bin/promote
-          sparse-checkout-cone-mode: false
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,11 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: bin/promote
+          sparse-checkout-cone-mode: false
+
       - uses: actions/download-artifact@v4
         with:
           pattern: "**/*.yaml"
@@ -187,10 +192,7 @@ jobs:
           cat **/*.yaml > restylers.yaml
 
       - name: Promote to sha tag
-        uses: restyled-io/sdk@main
-        with:
-          command: >-
-            promote --yes --no-test --file restylers.yaml ${{ github.sha }}
+        run: ./bin/promote ./restylers.yaml "${{ github.sha }}"
 
   release:
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -222,16 +224,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Promote to version tag
-        uses: restyled-io/sdk@main
-        with:
-          command: >-
-            promote --yes --no-test ${{ github.sha }} ${{ steps.tag.outputs.new_tag }}
+        run: ./bin/promote "${{ github.sha }}" "${{ steps.tag.outputs.new_tag }}"
 
       - name: Promote to dev
-        uses: restyled-io/sdk@main
-        with:
-          command: >-
-            promote --yes --no-test ${{ github.sha }} dev
+        run: ./bin/promote "${{ github.sha }}" "dev"
 
       - name: Notify
         uses: zulip/github-actions-zulip/send-message@v1.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,6 @@ jobs:
         name: Setup buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-${{ matrix.restyler }}-image-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.restyler }}-image-
-
       - name: Registry login
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
@@ -70,10 +62,9 @@ jobs:
         if: ${{ github.ref != 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
-          builder: ${{ steps.buildx.outputs.name }}
           context: ${{ matrix.restyler }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           outputs: type=docker
           tags: ${{ steps.prep.outputs.image }}
 
@@ -81,17 +72,11 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v6
         with:
-          builder: ${{ steps.buildx.outputs.name }}
           context: ${{ matrix.restyler }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.prep.outputs.image }}
-
-      - name: Cache cleanup
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Container credentials
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -59,11 +59,10 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
 
+      - uses: actions/checkout@v4
       - uses: restyled-io/actions/setup-demo@v2
         with:
           channel: ${{ steps.prep.outputs.from }}
-
-      - uses: actions/checkout@v4
       - uses: restyled-io/actions/setup@v2
       - uses: restyled-io/actions/run@v2
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -59,15 +59,11 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
 
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: bin/promote
-          sparse-checkout-cone-mode: false
-
       - uses: restyled-io/actions/setup-demo@v2
         with:
           channel: ${{ steps.prep.outputs.from }}
 
+      - uses: actions/checkout@v4
       - uses: restyled-io/actions/setup@v2
       - uses: restyled-io/actions/run@v2
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -59,6 +59,11 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
 
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: bin/promote
+          sparse-checkout-cone-mode: false
+
       - uses: restyled-io/actions/setup-demo@v2
         with:
           channel: ${{ steps.prep.outputs.from }}
@@ -67,11 +72,6 @@ jobs:
       - uses: restyled-io/actions/run@v2
         with:
           paths: .
-
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: bin/promote
-          sparse-checkout-cone-mode: false
 
       - run: ./bin/promote "${{ steps.prep.outputs.from }}" "${{ steps.prep.outputs.to }}"
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -6,6 +6,12 @@ on:
     - cron: "0 07 01 * *"
     - cron: "0 07 15 * *"
 
+  # Run it if touched
+  pull_request:
+    paths:
+      - .github/workflows/promote.yml
+
+  # Or manually trigger
   workflow_dispatch:
     inputs:
       from:
@@ -29,15 +35,45 @@ jobs:
     steps:
       - id: prep
         run: |
-          cat >>"$GITHUB_OUTPUT" <<EOM
-          from=${{ github.event.from || 'dev' }}
-          to=${{ github.event.to || 'stable' }}
-          EOM
+          case "$GITHUB_EVENT_NAME" in
+            'schedule')
+              # Promote dev to stable on the schedule
+              echo 'from=dev'
+              echo 'to=stable'
+            ;;
+            'pull_request')
+              # Promote dev to itself just to test our logic
+              echo 'from=dev'
+              echo 'to=dev'
+            ;;
+            'workflow_dispatch')
+              # Promote what was given
+              echo 'from=${{ github.event.from }}'
+              echo 'to=${{ github.event.to }}'
+            ;;
+            *)
+              echo "Unexpected event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+            ;;
+          esac >>"$GITHUB_OUTPUT"
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
 
-      - uses: restyled-io/sdk@main
+      - uses: restyled-io/actions/setup-demo@v2
         with:
-          command: >
-            promote --yes ${{ steps.prep.outputs.from }} ${{ steps.prep.outputs.to }}
+          channel: ${{ steps.prep.outputs.from }}
+
+      - uses: restyled-io/actions/setup@v2
+      - uses: restyled-io/actions/run@v2
+        with:
+          paths: .
+
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: bin/promote
+          sparse-checkout-cone-mode: false
+
+      - run: ./bin/promote "${{ steps.prep.outputs.from }}" "${{ steps.prep.outputs.to }}"
 
       - name: Notify
         if: always()

--- a/bin/promote
+++ b/bin/promote
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+get_stack_output() {
+  local stack=$1 output=$2
+
+  aws cloudformation describe-stacks \
+    --stack-name "$stack" \
+    --query "Stacks[*].Outputs[?OutputKey==\`$output\`].OutputValue" \
+    --output "text"
+}
+
+aws_cp() {
+  aws s3 cp --acl public-read --content-type text/plain "$@"
+}
+
+manifest_path() {
+  local channel=$1
+  printf '/data-files/restylers/manifests/%s/restylers.yaml' "$channel"
+}
+
+manifest_s3() {
+  local bucket=$1 channel=$2
+  printf 's3://%s%s' "$bucket" "$(manifest_path "$channel")"
+}
+
+read -r bucket < <(get_stack_output sites-docs BucketName)
+
+if [[ -f "$1" ]]; then
+  printf 'Promoting local file %s to channel %s\n' "$1" "$2"
+  aws_cp "$1" "$(manifest_s3 "$bucket" "$2")"
+else
+  printf 'Promoting channel %s to channel %s\n' "$1" "$2"
+  aws_cp "$(manifest_s3 "$bucket" "$1")" "$(manifest_s3 "$bucket" "$2")"
+fi
+
+read -r distribution_id < <(get_stack_output sites-docs DistributionId)
+
+aws cloudfront create-invalidation \
+  --distribution-id "$distribution_id" --paths "$(manifest_path "$2")"

--- a/hindent/Dockerfile
+++ b/hindent/Dockerfile
@@ -1,8 +1,8 @@
-FROM restyled/stack-build-minimal:22.04 as builder
+FROM fpco/stack-build-small:lts-22.31 AS builder
 LABEL maintainer="Pat Brisbin <pbrisbin@gmail.com>"
+RUN stack update # cache cabal files update
 ENV LANG en_US.UTF-8
 ENV PATH /root/.local/bin:$PATH
-RUN stack upgrade
 COPY stack.yaml /root/.stack/global-project/stack.yaml
 RUN stack install hindent
 

--- a/hindent/stack.yaml
+++ b/hindent/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.22
+resolver: lts-22.31
 packages: []
 extra-deps:
-  - hindent-5.3.4
+  - hindent-6.1.1


### PR DESCRIPTION
With all of the GitHub Actions-related changes, it's become much easier to do integration testing of Restylers manifests. The `setup-demo` action in particular sets up all Restylers' test files so that the `run` action can be used normally and it runs over all test files. This was effectively what we've done as integration testing through the SDK before. Now, it's much lighter to do anywhere, we do it in the actions test suite and the Restyler test suite already; might as well do it here now.

The other responsibilities of `promote` were to move some files around on S3, which I re-write here as `bin/promote`. Now we don't rely on that executable of the SDK at all.