### PR TITLE
Fix manifest handling on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,28 +153,16 @@ jobs:
           exit 1
 
   promote:
-    if: ${{ github.ref == 'refs/heads/main' }}
     needs: [test, test-external]
-
     runs-on: ubuntu-latest
-
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-      AWS_DEFAULT_REGION: us-east-1
-
     steps:
       - uses: actions/checkout@v4
       - uses: restyled-io/actions/setup-demo@v2
       - uses: restyled-io/actions/setup@v2
-
-      # Overwrite
       - uses: actions/download-artifact@v4
         with:
           pattern: "**/*.yaml"
-      - name: Build manifest
-        run: |
-          cat **/*.yaml > restylers.yaml
+      - run: "cat **/*.yaml > restylers.yaml"
 
       - uses: restyled-io/actions/run@v2
         with:
@@ -182,8 +170,13 @@ jobs:
           log-level: debug
           manifest: ./restylers.yaml
 
-      - name: Promote to sha tag
+      - if: ${{ github.ref == 'refs/heads/main' }}
+        name: Promote to sha tag
         run: ./bin/promote ./restylers.yaml "${{ github.sha }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_DEFAULT_REGION: us-east-1
 
   release:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
       - uses: restyled-io/actions/run@v2
         with:
           paths: .
+          log-level: debug
           manifest: ./restylers.yaml
 
       - name: Promote to sha tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,10 +169,13 @@ jobs:
       - run: |
           cat ./*-restyler-yaml/restyler.yaml > restylers.yaml
 
+      # Run with --dry-run, just to confirm the manifest parses. A fuller
+      # integration test is run before promoting to stable (not dev).
       - uses: restyled-io/actions/run@v2
         with:
           paths: .
           manifest: ./restylers.yaml
+          dry-run: true
 
       - if: ${{ github.ref == 'refs/heads/main' }}
         name: Promote to sha tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: "*-restyler-yaml"
-      - run: "cat */restyler.yaml > restylers.yaml"
+      - run: |
+          cat ./*-restyler-yaml/restyler.yaml > restylers.yaml
 
       - uses: restyled-io/actions/run@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           name: ${{ matrix.restyler }}-restyler-yaml
           path: restyler.yaml
+          if-no-files-found: error
 
   test-external:
     runs-on: ubuntu-latest
@@ -143,6 +144,7 @@ jobs:
         with:
           name: ${{ matrix.restyler }}-restyler-yaml
           path: restyler.yaml
+          if-no-files-found: error
 
   # See https://github.com/orgs/community/discussions/60792
   status:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,7 @@ jobs:
             ${{ matrix.restyler }}
             ${{ matrix.overrides }}
 
-      - if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.restyler }}
           path: restyler.yaml
@@ -136,8 +135,7 @@ jobs:
             --write restyler.yaml
             ${{ matrix.restyler }}
 
-      - if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.restyler }}
           path: restyler.yaml
@@ -161,8 +159,8 @@ jobs:
       - uses: restyled-io/actions/setup@v2
       - uses: actions/download-artifact@v4
         with:
-          pattern: "**/*.yaml"
-      - run: "cat **/*.yaml > restylers.yaml"
+          pattern: "*/restyler.yaml"
+      - run: "cat */restyler.yaml > restylers.yaml"
 
       - uses: restyled-io/actions/run@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,6 @@ jobs:
       - uses: restyled-io/actions/run@v2
         with:
           paths: .
-          log-level: debug
           manifest: ./restylers.yaml
 
       - if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,13 +165,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: restyled-io/actions/setup-demo@v2
+      - uses: restyled-io/actions/setup@v2
 
+      # Overwrite
       - uses: actions/download-artifact@v4
         with:
           pattern: "**/*.yaml"
       - name: Build manifest
         run: |
           cat **/*.yaml > restylers.yaml
+
+      - uses: restyled-io/actions/run@v2
+        with:
+          paths: .
+          manifest: ./restylers.yaml
 
       - name: Promote to sha tag
         run: ./bin/promote ./restylers.yaml "${{ github.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.restyler }}
+          name: ${{ matrix.restyler }}-restyler-yaml
           path: restyler.yaml
 
   test-external:
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.restyler }}
+          name: ${{ matrix.restyler }}-restyler-yaml
           path: restyler.yaml
 
   # See https://github.com/orgs/community/discussions/60792
@@ -159,7 +159,7 @@ jobs:
       - uses: restyled-io/actions/setup@v2
       - uses: actions/download-artifact@v4
         with:
-          pattern: "*/restyler.yaml"
+          pattern: "*-restyler-yaml"
       - run: "cat */restyler.yaml > restylers.yaml"
 
       - uses: restyled-io/actions/run@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DOCKER_BUILD_SUMMARY: "false"
+  DOCKER_BUILD_RECORD_UPLOAD: "false"
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Somehow we ended up promoting without downloading artifacts, that meant that `**/*.yaml` was picking up all our `info.yaml` files and concatenating them, making an invalid manifest that we promoted to dev.

To avoid this in the future, we add a test step when promoting the sha tag manifest, so we know it's valid before promoting even that. That eventually becomes the version and dev, and then later stable, manifests, so we should be fully covered now.