### PR TITLE
Fix release workflow, update fourmolu to v0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         with:
           tag: dev
           force_push_tag: true
-          commit_sha: "${{ steps.tag.outputs.new_tag }}^{}"
+          commit_sha: ${{ github.sha }}
 
       - name: Update dev release
         uses: softprops/action-gh-release@v2

--- a/_tools/restylers/app/Main.hs
+++ b/_tools/restylers/app/Main.hs
@@ -37,7 +37,9 @@ main = do
         then logWarn "Not pushing, image exists"
         else do
           pushRestylerImage restyler.image
-          traverse_ (traverse_ pushRestylerImage) $ getSeriesImages restyler.image
+          case getSeriesImages restyler.image of
+            Nothing -> logWarn "Image is not semantically-versioned"
+            Just is -> traverse_ pushRestylerImage is
 
     traverse_ (liftIO . (`Manifest.write` restylers)) opts.write
 

--- a/fourmolu/Dockerfile
+++ b/fourmolu/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   locale-gen en_US.UTF-8 && \
   rm -rf /var/lib/apt/lists/*
 ENV LANG=en_US.UTF-8
-ENV FOURMOLU_VERSION=0.14.1.0
+ENV FOURMOLU_VERSION=0.15.0.0
 RUN \
   curl -L -o /usr/bin/fourmolu \
   https://github.com/fourmolu/fourmolu/releases/download/v${FOURMOLU_VERSION}/fourmolu-${FOURMOLU_VERSION}-linux-x86_64 && \


### PR DESCRIPTION
### [Go back to github.sha for dev tag update](https://github.com/restyled-io/restylers/pull/796/commits/354e775ff060c2f69678db118e5ff250ac4d4dae)
[354e775](https://github.com/restyled-io/restylers/pull/796/commits/354e775ff060c2f69678db118e5ff250ac4d4dae)

The release tag isn't present in the local checkout (created via API, I
think), and it'd be annoying to pull. We know it's this sha, so we can
just use that.

### [feat(fourmolu): update to v0.15](https://github.com/restyled-io/restylers/pull/796/commits/7bb80da83f866d3bec52860f6695cd8a7724e1d4)
[7bb80da](https://github.com/restyled-io/restylers/pull/796/commits/7bb80da83f866d3bec52860f6695cd8a7724e1d4)

### [[tools] warn when not semantically-versioned](https://github.com/restyled-io/restylers/pull/796/commits/13dc13c4238977b7aa5d8240e004a7ae31e7368f)