### PR TITLE
Release changes, update fourmolu to v0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
 
       - name: Build merged restylers.yaml
         run: |
-          curl -sSf -L -o base.yaml \
-            https://docs.restyled.io/data-files/restylers/manifests/dev/restylers.yaml
+          gh release download dev -p restylers.yaml
+          mv -v restylers.yaml base.yaml
 
           ruby -r yaml > restylers.yaml <<'EOM'
           base = YAML.safe_load_file("./base.yaml")
@@ -104,6 +104,12 @@ jobs:
           echo "::group::Merged manifest"
           cat restylers.yaml
           echo "::endgroup::"
+
+          echo "::group::Changes"
+          diff -U 3 base.yaml restylers.yaml
+          echo "::endgroup::"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: update CLI to use release artifacts and stop managing this
-      - run: ./bin/promote ./restylers.yaml dev
+      - run: ./bin/promote dev
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,12 +163,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: create dev and stable releases, download manifests from them
-      # instead of maintaining these files on S3.
-      - name: Release sha, versioned, and dev manifests
-        run: |
-          ./bin/promote ./restylers.yaml \
-            "${{ github.sha }}" "${{ steps.tag.outputs.new_tag }}" "dev"
+      # TODO: update CLI to use release artifacts and stop managing this
+      - run: ./bin/promote ./restylers.yaml dev
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Changes"
-          diff -U 3 base.yaml restylers.yaml
+          diff -U 3 base.yaml restylers.yaml || true
           echo "::endgroup::"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -94,7 +94,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: update CLI to use release artifacts and stop managing this
-      - run: ./bin/promote restylers.yaml "${{ steps.prep.outputs.to }}"
+      - run: ./bin/promote "${{ steps.prep.outputs.to }}"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -24,14 +24,8 @@ on:
         default: stable
 
 jobs:
-  release:
+  promote:
     runs-on: ubuntu-latest
-
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-      AWS_DEFAULT_REGION: us-east-1
-
     steps:
       - id: prep
         run: |
@@ -61,11 +55,13 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # so we can find from tag refs
+          fetch-depth: 0 # so we can find from-tag refs
+
       - id: setup-demo
         uses: restyled-io/actions/setup-demo@v3
         with:
           channel: ${{ steps.prep.outputs.from }}
+
       - uses: restyled-io/actions/setup@v3
       - uses: restyled-io/actions/run@v3
         with:
@@ -75,8 +71,6 @@ jobs:
           manifest: ${{ steps.setup-demo.outputs.manifest }}
           dry-run: ${{ github.event_name == 'pull_request' }}
           paths: .
-
-      - run: ./bin/promote "${{ steps.prep.outputs.from }}" "${{ steps.prep.outputs.to }}"
 
       - name: Download ${{ steps.prep.outputs.from }} release manifest
         run: gh release download "${{ steps.prep.outputs.from }}" -p restylers.yaml
@@ -99,15 +93,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Notify
-        if: always()
-        uses: zulip/github-actions-zulip/send-message@v1.0.2
-        with:
-          api-key: ${{ secrets.ZULIP_API_KEY }}
-          email: ${{ secrets.ZULIP_EMAIL }}
-          organization-url: ${{ secrets.ZULIP_ORGANIZATION_URL }}
-          to: 'changelog'
-          type: 'stream'
-          topic: 'Restylers Releases'
-          content: |
-            Promotion of `${{ steps.prep.outputs.from }}` to `${{ steps.prep.outputs.to }}`: ${{ job.status }}
+      # TODO: update CLI to use release artifacts and stop managing this
+      - run: ./bin/promote "${{ steps.prep.outputs.from }}" "${{ steps.prep.outputs.to }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -94,7 +94,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: update CLI to use release artifacts and stop managing this
-      - run: ./bin/promote "${{ steps.prep.outputs.from }}" "${{ steps.prep.outputs.to }}"
+      - run: ./bin/promote restylers.yaml "${{ steps.prep.outputs.to }}"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}

--- a/bin/promote
+++ b/bin/promote
@@ -1,65 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-tmp=$(mktemp '/tmp/sites-docs-stack-outputs-XXXXXX.json')
-trap 'rm -f "$tmp"' EXIT
-
-aws cloudformation describe-stacks \
-  --stack-name sites-docs \
-  --query "Stacks[*].Outputs[]" \
-  --output "json" >"$tmp"
-
-read_output() {
-  jq --raw-output ".[] | select(.OutputKey == \"$1\") | .OutputValue" <"$tmp" |
-    head -n 1
-}
-
-read -r bucket < <(read_output BucketName)
-read -r distribution_id < <(read_output DistributionId)
-
-if [[ -z "$bucket" ]]; then
-  echo "Unabled to determine manifests bucket" >&2
-  exit 1
-fi
-
-if [[ -z "$distribution_id" ]]; then
-  echo "Unabled to determine CloudFront distribution" >&2
-  exit 1
-fi
-
-if ((!$#)); then
-  echo "Usage: bin/promote <from> <to> [to...]" >&2
+if (($# != 2)); then
+  echo "Usage: bin/promote <file> <channel>" >&2
   exit 64
 fi
 
-manifest_fmt='/data-files/restylers/manifests/%s/restylers.yaml'
-
-# shellcheck disable=SC2059
-manifest_cf() { printf "$manifest_fmt" "$1"; }
-manifest_s3() { printf "s3://%s$manifest_fmt" "$bucket" "$1"; }
-
-if [[ -f "$1" ]]; then
-  printf 'Promoting from local file: %s\n' "$1"
-  src=$1
-else
-  printf 'Promoting from channel: %s\n' "$1"
-  src="$(manifest_s3 "$1")"
+if [[ ! -f "$1" ]]; then
+  echo "<from> must be a file" >&2
+  exit 1
 fi
 
-shift
+bucket=sites-docs-bucket-1vleclrg7tli7
+prefix=data-files/restylers/manifests
+name=restylers.yaml
+distribution_id=E539B2WJC12CB
 
-for arg; do
-  printf 'Promoting to channel: %s\n' "$arg"
-done
+path=$1
+channel=$2
 
-if [[ -n "${DRY_RUN:-""}" ]]; then
-  echo "=> Exiting due to DRY_RUN" >&2
-  exit
-fi
+aws s3 cp --acl public-read --content-type text/plain "$path" \
+  "s3://$bucket/$prefix/$channel/$name"
 
-for arg; do
-  dst_s3="$(manifest_s3 "$arg")"
-  dst_cf="$(manifest_cf "$arg")"
-  aws s3 cp --acl public-read --content-type text/plain "$src" "$dst_s3"
-  aws cloudfront create-invalidation --distribution-id "$distribution_id" --paths "$dst_cf"
-done
+aws cloudfront create-invalidation \
+  --distribution-id "$distribution_id" \
+  --paths "/$prefix/$channel/$name"

--- a/bin/promote
+++ b/bin/promote
@@ -1,27 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if (($# != 2)); then
-  echo "Usage: bin/promote <file> <channel>" >&2
+bucket=sites-docs-bucket-1vleclrg7tli7
+prefix=data-files/restylers/manifests
+distribution_id=E539B2WJC12CB
+
+if (($# != 1)); then
+  echo "Usage: bin/promote <channel>" >&2
+  echo "Upload restylers.yaml to s3://.../channel/restylers.yaml" >&2
   exit 64
 fi
 
-if [[ ! -f "$1" ]]; then
-  echo "<from> must be a file" >&2
+path=restylers.yaml
+channel=$1
+
+if [[ ! -f "$path" ]]; then
+  echo "$path: file not found" >&2
   exit 1
 fi
 
-bucket=sites-docs-bucket-1vleclrg7tli7
-prefix=data-files/restylers/manifests
-name=restylers.yaml
-distribution_id=E539B2WJC12CB
-
-path=$1
-channel=$2
-
 aws s3 cp --acl public-read --content-type text/plain "$path" \
-  "s3://$bucket/$prefix/$channel/$name"
+  "s3://$bucket/$prefix/$channel/$path"
 
 aws cloudfront create-invalidation \
   --distribution-id "$distribution_id" \
-  --paths "/$prefix/$channel/$name"
+  --paths "/$prefix/$channel/$path"

--- a/fourmolu/Dockerfile
+++ b/fourmolu/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   locale-gen en_US.UTF-8 && \
   rm -rf /var/lib/apt/lists/*
 ENV LANG=en_US.UTF-8
-ENV FOURMOLU_VERSION=0.15.0.0
+ENV FOURMOLU_VERSION=0.16.2.0
 RUN \
   curl -L -o /usr/bin/fourmolu \
   https://github.com/fourmolu/fourmolu/releases/download/v${FOURMOLU_VERSION}/fourmolu-${FOURMOLU_VERSION}-linux-x86_64 && \


### PR DESCRIPTION
### [[release] promote job changes](https://github.com/restyled-io/restylers/pull/797/commits/4f28947c4c0ba3c404ae68a06f671554f2b9a8fb)
[4f28947](https://github.com/restyled-io/restylers/pull/797/commits/4f28947c4c0ba3c404ae68a06f671554f2b9a8fb)

- Rename promote job
- Remove promote zulip notification
- Move deprecated manifest step to end of workflow
- Whitespace

### [[release] Always and only use promote with files](https://github.com/restyled-io/restylers/pull/797/commits/ca5e502087a11c20d9975d1a743c54fb04729374)
[ca5e502](https://github.com/restyled-io/restylers/pull/797/commits/ca5e502087a11c20d9975d1a743c54fb04729374)

And stop releasing legacy manifests as version and sha channels.

### [[release] Make use of artifacts in merging restylers.yaml](https://github.com/restyled-io/restylers/pull/797/commits/587d8121edf0f41289d2d2b4e03c1f79eedb9ad9)
[587d812](https://github.com/restyled-io/restylers/pull/797/commits/587d8121edf0f41289d2d2b4e03c1f79eedb9ad9)

### [[release] Simplify bin/promote](https://github.com/restyled-io/restylers/pull/797/commits/050d9e600341bf76e591784476d19c67ccfb9473)
[050d9e6](https://github.com/restyled-io/restylers/pull/797/commits/050d9e600341bf76e591784476d19c67ccfb9473)

### [[release] Always upload from ./restylers.yaml](https://github.com/restyled-io/restylers/pull/797/commits/27d8b8225ec7c02742dd2316816d4553bd15255c)
[27d8b82](https://github.com/restyled-io/restylers/pull/797/commits/27d8b8225ec7c02742dd2316816d4553bd15255c)

### [feat(fourmolu): update to v0.16](https://github.com/restyled-io/restylers/pull/797/commits/2234d0d34bacf6b3e770bca85984fa3609eabdc0)