### PR TITLE
Stop running jq automatically

### DIFF
--- a/jq/info.yaml
+++ b/jq/info.yaml
@@ -1,5 +1,5 @@
 ---
-enabled: true
+enabled: false
 name: jq
 version: v1.6-3
 command:


### PR DESCRIPTION
We added this Restyler before prettier-json existed. Then, when we added prettier-json, we also made it automatically enabled. Now they tend to fight each other and potentially produce 0-diff PRs. prettier-json is better, so let's enable only that.