### PR TITLE
Update nixfmt to commit used by nixfmt-rfc-style on nixpkgs 24.05

### DIFF
--- a/_tools/restylers/src/Restylers/Test.hs
+++ b/_tools/restylers/src/Restylers/Test.hs
@@ -115,6 +115,7 @@ runRestyler pull code = do
         , ["--host-directory", code]
         , ["--manifest", testManifest]
         , ["--no-commit"]
+        , ["--no-clean"]
         , ["--no-pull" | not pull]
         , ["."]
         ]

--- a/nixfmt/Dockerfile
+++ b/nixfmt/Dockerfile
@@ -1,7 +1,7 @@
 FROM nixos/nix:2.24.1
 LABEL maintainer="Chris Martin <ch.martin@gmail.com>"
 RUN echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
-RUN nix profile install --impure 'github:NixOS/nixfmt?rev=698954723ecec3f91770460ecae762ce590f2d9e'
+RUN nix profile install --impure 'github:NixOS/nixfmt?rev=83de1eceaae8a891ae52a3a2b82226540207309e'
 RUN nix profile install --impure 'nixpkgs#gnused'
 RUN mkdir -p /code
 WORKDIR /code


### PR DESCRIPTION
Nixfmt is becoming the standard Nix formatter. There are two styles of nixfmt: `nixfmt-rfc-style` and `nixfmt-classic`. When nixfmt was originally added to Restyled, `nixfmt-classic` was still `nixfmt` and was not deprecated yet. Now `nixfmt-classic` is no longer maintained. This PR updates the commit of nixfmt to the version in nix 24.05 stable.