### PR TITLE
Ensure restylers are tested on only their test files

### DIFF
--- a/_tools/restylers/src/Restylers/Info/Test.hs
+++ b/_tools/restylers/src/Restylers/Info/Test.hs
@@ -44,11 +44,11 @@ writeTestFiles
   -> RestylerName
   -> [Text]
   -> Test
-  -> m ()
+  -> m FilePath
 writeTestFiles number name include test@Test {contents, support} = do
   logInfo $ "CREATE" :# ["path" .= path]
   liftIO $ T.writeFile path contents
-  traverse_ writeSupportFile support
+  path <$ traverse_ writeSupportFile support
  where
   path = testFilePath number name include test
 


### PR DESCRIPTION
Testing multiple restylers at once, that operate on the same files, were
operating on each others test files and causing failures.

To address this, we take the files created for each restyler and then
put only them as the configured `include` for that restyler when the
tests are run. This ensures isolation.

It's possible we still have isolation bugs with shebang-based restyling,
but we'll cross that bridge when it causes a failure.
