### PR TITLE
Add prettier plugin to sort imports

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -2,59 +2,15 @@ name: Restyled
 
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - closed
-      - synchronize
 
 jobs:
   restyled:
-    if: |
-      github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: restyled-io/actions/setup@v4
-      - id: restyler
-        uses: restyled-io/actions/run@v4
-        with:
-          fail-on-differences: true
-      - if: ${{ !cancelled() && steps.restyler.outputs.success == 'true' }}
-        uses: peter-evans/create-pull-request@v7
-        with:
-          base: ${{ steps.restyler.outputs.restyled-base }}
-          branch: ${{ steps.restyler.outputs.restyled-head }}
-          title: ${{ steps.restyler.outputs.restyled-title }}
-          body: ${{ steps.restyler.outputs.restyled-body }}
-          labels: restyled
-          reviewers: ${{ github.event.pull_request.user.login }}
-          delete-branch: true
-
-  restyled-fork:
-    if: |
-      github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: restyled-io/actions/setup@v4
       - uses: restyled-io/actions/run@v4
         with:
-          fail-on-differences: true
-
-  restyled-cleanup:
-    if: ${{ github.event.action == 'closed' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: restyled-io/actions/setup@v4
-      - id: restyler
-        uses: restyled-io/actions/run@v4
-      - run: gh --repo "$REPO" pr close "$BRANCH" --delete-branch || true
-        env:
-          REPO: ${{ github.repository }}
-          BRANCH: ${{ steps.restyler.outputs.restyled-head }}
-          GH_TOKEN: ${{ github.token }}
+          suggestions: true

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - uses: restyled-io/actions/setup@v4
       - uses: restyled-io/actions/run@v4
         with:

--- a/_tools/restylers/src/Restylers/Info/Test.hs
+++ b/_tools/restylers/src/Restylers/Info/Test.hs
@@ -22,7 +22,7 @@ import Data.Aeson
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import Restylers.Info.Test.Support (Support, writeSupportFile)
+import Restylers.Info.Test.Support (Support)
 import Restylers.Name
 import System.FilePath (takeExtension)
 
@@ -45,10 +45,9 @@ writeTestFiles
   -> [Text]
   -> Test
   -> m FilePath
-writeTestFiles number name include test@Test {contents, support} = do
+writeTestFiles number name include test@Test {contents} = do
   logInfo $ "CREATE" :# ["path" .= path]
-  liftIO $ T.writeFile path contents
-  path <$ traverse_ writeSupportFile support
+  path <$ liftIO (T.writeFile path contents)
  where
   path = testFilePath number name include test
 

--- a/_tools/restylers/src/Restylers/Info/Test/Support.hs
+++ b/_tools/restylers/src/Restylers/Info/Test/Support.hs
@@ -10,7 +10,7 @@
 -- Portability : POSIX
 module Restylers.Info.Test.Support
   ( Support (..)
-  , writeSupportFile
+  , withSupportFile
   )
 where
 
@@ -18,6 +18,8 @@ import Restylers.Prelude
 
 import Data.Aeson
 import Data.Text.IO qualified as T
+import UnliftIO.Directory (removeFile)
+import UnliftIO.Exception (finally)
 
 data Support = Support
   { path :: FilePath
@@ -26,12 +28,11 @@ data Support = Support
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
-writeSupportFile
-  :: ( MonadIO m
-     , MonadLogger m
-     )
+withSupportFile
+  :: MonadUnliftIO m
   => Support
-  -> m ()
-writeSupportFile Support {path, contents} = do
-  logInfo $ "CREATE" :# ["path" .= path]
+  -> m a
+  -> m a
+withSupportFile Support {path, contents} f = do
   liftIO $ T.writeFile path contents
+  f `finally` removeFile path

--- a/prettier/Dockerfile
+++ b/prettier/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY package.json .
 RUN yarn install && yarn cache clean
 RUN cd node_modules/tailwindcss && yarn link
+RUN cd node_modules/@trivago/prettier-plugin-sort-imports && yarn link
 ENV PATH=/app/node_modules/.bin:$PATH
 COPY prettier-with-tailwindcss /usr/local/bin/prettier-with-tailwindcss
 RUN mkdir -p /code

--- a/prettier/info.yaml
+++ b/prettier/info.yaml
@@ -44,3 +44,17 @@ metadata:
         )
       restyled: |
         matrix(1, 0, 0, 0, 1, 0, 0, 0, 1);
+    - name: With import sorting plugin
+      support:
+        path: .prettierrc.json
+        contents: |
+          {"plugins": ["@trivago/prettier-plugin-sort-imports"]}
+      extension: js
+      contents: |
+        import c from 'moduleC';
+        import a from 'moduleA';
+        import b from 'moduleB';
+      restyled: |
+        import a from "moduleA";
+        import b from "moduleB";
+        import c from "moduleC";

--- a/prettier/package.json
+++ b/prettier/package.json
@@ -2,6 +2,7 @@
   "name": "@restyled/restyler-prettier",
   "version": "0.0.0",
   "dependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "prettier": "3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.0",
     "tailwindcss": "^3.3.2"

--- a/prettier/prettier-with-tailwindcss
+++ b/prettier/prettier-with-tailwindcss
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
-yarn link tailwindcss
-trap 'yarn unlink tailwindcss' EXIT
+#
+# NB. this executable handles link/unlink of all plugins, not just tailwind, but
+# we're keeping it named as is to avoid errors for users who may be using
+# command in their .restyled.yaml
+#
+###
+yarn link tailwindcss @trivago/prettier-plugin-sort-imports
+trap 'yarn unlink tailwindcss @trivago/prettier-plugin-sort-imports' EXIT
 prettier "$@"


### PR DESCRIPTION
I added a plugin to prettier config to sort imports. This currently breaks restyler when it isn't installed. I think the fix is as simple as just adding the dependency to package.json