### PR TITLE
pb/npm groovy lint

### DIFF
--- a/_tools/restylers/src/Restylers/Test.hs
+++ b/_tools/restylers/src/Restylers/Test.hs
@@ -91,6 +91,7 @@ testRestylers pull restylers hspecArgs = do
                         , ["--no-commit"]
                         , ["--no-clean"]
                         , ["--no-pull" | not pull]
+                        , ["--restyler-memory", "512m"]
                         , ["."]
                         ]
 

--- a/npm-groovy-lint/Dockerfile
+++ b/npm-groovy-lint/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21.7-slim
+FROM node:22.11-slim
 LABEL maintainer="Pat Brisbin <pbrisbin@gmail.com>"
 ENV LANG en_US.UTF-8
 RUN mkdir -p /app

--- a/npm-groovy-lint/npm-groovy-lint
+++ b/npm-groovy-lint/npm-groovy-lint
@@ -1,5 +1,16 @@
 #!/bin/sh
-# If you use --failon=none, that doesn't just prevent the non-zero exit code, oh
-# no, it disables all fixing and formatting too! So we need this dumb wrapper
-# that just ignores the exit code instead.
-/app/node_modules/.bin/npm-groovy-lint "$@" || true
+/app/node_modules/.bin/npm-groovy-lint "$@"
+ret=$?
+
+case $ret in
+  1)
+    # This tool lacks a --no-exit-code type of option, and it exits 1 when it
+    # has found/fixed issues. So we'll exit 0 on that case.
+    exit 0
+    ;;
+  *)
+    # Any other code will be respected, because there is a few that have meaning
+    # (e.g. 9 for out of memory)
+    exit $ret
+    ;;
+esac


### PR DESCRIPTION
- **Bump npm-groovy-lint version**
- **Update npm-groovy-lint wrapper to respect exit 9**
- **Give a little more memory in restyler tests**
