### PR TITLE
Force release of prettier

### DIFF
--- a/prettier/info.yaml
+++ b/prettier/info.yaml
@@ -2,7 +2,7 @@
 enabled: true
 name: prettier
 version_cmd: |
-  prettier --version | sed 's/^/v/; s/$/-2/'
+  prettier --version | sed 's/^/v/; s/$/-3/'
 command:
   - prettier
   - "--write"


### PR DESCRIPTION
Somehow the `v3` images aren't up to date. I can't explain how, but they
lack the update with import sorting.
