### PR TITLE
fix: avoid automatic module linking in non-JS prettier restylers

### DIFF
--- a/prettier-json/info.yaml
+++ b/prettier-json/info.yaml
@@ -1,6 +1,9 @@
 ---
 overrides: prettier
 name: prettier-json
+command:
+  - /app/node_modules/.bin/prettier
+  - "--write"
 include:
   - "**/*.json"
 documentation:

--- a/prettier-markdown/info.yaml
+++ b/prettier-markdown/info.yaml
@@ -1,6 +1,9 @@
 ---
 overrides: prettier
 name: prettier-markdown
+command:
+  - /app/node_modules/.bin/prettier
+  - "--write"
 include:
   - "**/*.md"
   - "**/*.markdown"

--- a/prettier-yaml/info.yaml
+++ b/prettier-yaml/info.yaml
@@ -1,6 +1,9 @@
 ---
 overrides: prettier
 name: prettier-yaml
+command:
+  - /app/node_modules/.bin/prettier
+  - "--write"
 include:
   - "**/*.yml"
   - "**/*.yaml"


### PR DESCRIPTION
The `prettier` on `$PATH` is our own shim with logic to link certain
node modules into the project. This is needed to ensure formatting
JavaScript works when using them.

This code breaks when a vendored `yarn` is in use[^1]. A known
workaround, for any case that doesn't actually need these plugins, is to
update `command` to bypass our shim. Since any non-JavaScript `prettier`
restyler would never need such plugins, we can apply this workaround
ourselves.

[^1]: https://github.com/restyled-io/restylers/issues/928
