### PR TITLE
Add ruff Python formatter and linter

### DIFF
--- a/ruff/Dockerfile
+++ b/ruff/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.13-alpine
+ENV LANG C.UTF-8
+RUN pip install --no-cache-dir ruff
+WORKDIR /code
+ENTRYPOINT []
+CMD ["ruff", "--help"]

--- a/ruff/info.yaml
+++ b/ruff/info.yaml
@@ -1,0 +1,55 @@
+---
+enabled: false
+name: ruff
+version_cmd: |
+  ruff --version | sed '/^ruff \(.*\)$/!d; s//v\1/'
+command:
+  - ruff
+  - format
+supports_arg_sep: true
+supports_multiple_paths: true
+include:
+  - "**/*.py"
+documentation:
+  - https://docs.astral.sh/ruff
+metadata:
+  languages:
+    - Python
+  tests:
+    - contents: |
+        import math, sys;
+        def example1():
+            ####This is a long comment. This should be wrapped to fit within 72 characters.
+            some_tuple=(   1,2, 3,'a'  );
+            some_variable={'long':'Long code lines should be wrapped within 79 characters.',
+            'other':[math.pi, 100,200,300,9876543210,'This is a long string that goes on'],
+            'more':{'inner':'This whole logical line should be wrapped.',some_tuple:[1,
+            20,300,40000,500000000,60000000000000000]}}
+            return (some_tuple, some_variable)
+
+      # NB. This file was reused from the autopep8 tests, so some of the things it
+      # states within itself (such as wrapping the comment) aren't actually
+      # handled by ruff with default setup.
+      restyled: |
+        import math, sys
+
+
+        def example1():
+            ####This is a long comment. This should be wrapped to fit within 72 characters.
+            some_tuple = (1, 2, 3, "a")
+            some_variable = {
+                "long": "Long code lines should be wrapped within 79 characters.",
+                "other": [
+                    math.pi,
+                    100,
+                    200,
+                    300,
+                    9876543210,
+                    "This is a long string that goes on",
+                ],
+                "more": {
+                    "inner": "This whole logical line should be wrapped.",
+                    some_tuple: [1, 20, 300, 40000, 500000000, 60000000000000000],
+                },
+            }
+            return (some_tuple, some_variable)


### PR DESCRIPTION
Ruff can act as formatter or as a linter. In the linter mode it can also apply fixes which might be valuable by some users.

Usage as formatter (by default acts mostly as `black` tool):
```sh
ruff format -- <path/to/dir> <path/to/file.py> ...
```

Usage as linter with auto-fix without reporting not fixed lint violations:
```sh
ruff check --fix-only -- <path/to/dir> <path/to/file.py> ...
```