### PR TITLE
fix(ruff): trigger release

### DIFF
--- a/ruff/info.yaml
+++ b/ruff/info.yaml
@@ -27,8 +27,8 @@ metadata:
             20,300,40000,500000000,60000000000000000]}}
             return (some_tuple, some_variable)
 
-      # NB. This file was reused from the autopep8 tests, so some of the things it
-      # states within itself (such as wrapping the comment) aren't actually
+      # NB. This file was reused from the autopep8 tests, so some of the things
+      # it states within itself (such as wrapping the comment) aren't actually
       # handled by ruff with default setup.
       restyled: |
         import math, sys


### PR DESCRIPTION
For a change to get released, two things must happen:

1. The commit must use a semantic commit message that triggers release
   (or the release workflow will not run)
2. The commit must include a change to that restyler's source (or it's
   not processed by CI/CD at all)

With ruff, the original PR did (2) but not (1). Then, when I tried to
trigger release later, I did (1) but not (2). I'll be looking into ways
to make this less likely to get wrong, but this commit does both.
