### PR TITLE
feat(ruff): separate command and arguments

### DIFF
--- a/ruff/info.yaml
+++ b/ruff/info.yaml
@@ -5,6 +5,7 @@ version_cmd: |
   ruff --version | sed '/^ruff \(.*\)$/!d; s//v\1/'
 command:
   - ruff
+arguments:
   - format
 supports_arg_sep: true
 supports_multiple_paths: true


### PR DESCRIPTION
This change will allow to overwrite arguments without changing the command (application), e.g.:

```yaml
restylers:
  - name: ruff
    arguments:
      - check
      - --fix-only
```