### PR TITLE
fix(shellharden): update to 4.3.1

### DIFF
--- a/shellharden/Dockerfile
+++ b/shellharden/Dockerfile
@@ -1,15 +1,16 @@
-FROM rust:alpine3.10
-LABEL maintainer="Pat Brisbin <pbrisbin@gmail.com>"
-ENV LANG en_US.UTF-8
+FROM alpine:3.23.3
+LABEL maintainer="Patrick Brisbin <pbrisbin@gmail.com>"
+RUN apk add --no-cache bash curl
 
-# renovate: datasource=crate depName=shellharden
-ENV SHELLHARDEN_VERSION=4.1.1
+# renovate: datasource=github-releases depName=shellharden packageName=anordal/shellharden
+ENV SHELLHARDEN_VERSION=4.3.1
 
-# https://github.com/rust-lang/cargo/issues/10303#issuecomment-1015007926
+ENV SHELLHARDEN_SRC_URL=https://github.com/anordal/shellharden/releases/download/v${SHELLHARDEN_VERSION}/shellharden-x86_64-unknown-linux-musl.tar.gz
+
 RUN \
-  apk add --no-cache --virtual .build-deps git && \
-  CARGO_NET_GIT_FETCH_WITH_CLI=true cargo install shellharden --vers "$SHELLHARDEN_VERSION" && \
-  apk del .build-deps
+  cd /tmp && \
+  curl -Ssf -L "$SHELLHARDEN_SRC_URL" | tar xzf - && \
+  mv ./shellharden /usr/bin/shellharden
 
 WORKDIR /code
 ENTRYPOINT []


### PR DESCRIPTION
The crate datasource in Renovate does not seem to be working[^1]. As of
v4.3.1 binary releases are available, so we can move to that.

[^1]: https://github.com/renovatebot/renovate/discussions/43324
