### PR TITLE
fix(shellharden): use version_cmd

### DIFF
--- a/shellharden/info.yaml
+++ b/shellharden/info.yaml
@@ -1,7 +1,8 @@
 ---
 enabled: true
 name: shellharden
-version: v4.1.1-3
+version_cmd:
+  shellharden --version | sed 's/^/v/'
 command:
   - shellharden
   - "--replace"

--- a/shellharden/info.yaml
+++ b/shellharden/info.yaml
@@ -1,7 +1,7 @@
 ---
 enabled: true
 name: shellharden
-version_cmd:
+version_cmd: |
   shellharden --version | sed 's/^/v/'
 command:
   - shellharden


### PR DESCRIPTION
We updated `shellharden` recently, but didn't realize it was using
hard-coded `version`.

NOTE: this likely resulted in an image tagged incorrectly, but we're not
going to go back and fix that.
