### PR TITLE
chore(ci): filter-scopes from dev, not before

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         name: Identify Restyler changes
         run: |
           base=${{ github.event.pull_request.base.sha }}
-          base=${base:-${{ github.event.before }}}
+          base=${base:-dev}
           ./.github/bin/filter-scopes "$base" >>"$GITHUB_OUTPUT"
     outputs:
       restylers: ${{ steps.scopes.outputs.restylers }}


### PR DESCRIPTION
This way, all commits since the last release/promote are investigated
and so if CI had failed for them, they will continue to get picked up
until they are successfully incorporated into `dev`.

It's OK if this process has false-positives (we'll just over test
things), and this approach avoids more false-negatives.
